### PR TITLE
Propagate Python exceptions through Cython wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 This is the first official release of scikit-SUNDAE. Main features/capabilities are listed below.
 
 ### Features
+- Python errors can be propagated through Cython wrappers
 - Implicit differential algebraic (IDA) solver for differential algebraic equations (DAEs)
 - C-based variable-coeffecients ordinary differential equations (CVODE) solver
 - Events functions with scipy-like API, including "terminal" and "direction" options

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ plt.show()
 * Check the [solve_ivp](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html) documentation from scipy or the [scipy-dae](https://pypi.org/project/scipy-dae/) package repository if you are looking for common examples to test out and compare against. Translating an example from another package can help you learn how to use scikit-SUNDAE before trying to solve more challenging problems.
 
 ## Citing this Work
-This work was authored by researchers at the National Renewable Energy Laboratory (NREL). The project is tracked in NREL's software records under SWR-24-137 and has a DOI available for citing the work. If you use use this package in your work, please include the following citation:
+This work was authored by researchers at the National Renewable Energy Laboratory (NREL). If you use use this package in your work, please include the following citation:
 
-> Randall, Corey R. "scikit-SUNDAE ((SUN)DIALS Differential Algebraic Equations) [SWR-24-137]." Computer software. url: https://github.com/NREL/scikit-sundae. doi: https://doi.org/10.11578/dc.20241104.3.
+> Randall, Corey R. "scikit-SUNDAE: A scikit with Python bindings to SUNDIALS Differential Algebraic Equation solvers [SWR-24-137]." Computer software. url: https://github.com/NREL/scikit-sundae. doi: https://doi.org/10.11578/dc.20241104.3.
 
 For convenience, we also provide the following for your BibTex:
 
 ```
 @misc{Randall-2024,
-  title = {{scikit-SUNDAE ((SUN)DIALS Differential Algebraic Equations) [SWR-24-137]}},
+  title = {{scikit-SUNDAE: A scikit with Python bindings to SUNDIALS Differential Algebraic Equation solvers [SWR-24-137]}},
   author = {Randall, Corey R.},
   doi = {10.11578/dc.20241104.3},
   url = {https://github.com/NREL/scikit-sundae},

--- a/README.md
+++ b/README.md
@@ -85,17 +85,17 @@ plt.show()
 ## Citing this Work
 This work was authored by researchers at the National Renewable Energy Laboratory (NREL). The project is tracked in NREL's software records under SWR-24-137 and has a DOI available for citing the work. If you use use this package in your work, please include the following citation:
 
-> Placeholder... waiting for DOI.
+> Randall, Corey R. "scikit-SUNDAE ((SUN)DIALS Differential Algebraic Equations) [SWR-24-137]." Computer software. url: https://github.com/NREL/scikit-sundae. doi: https://doi.org/10.11578/dc.20241104.3.
 
 For convenience, we also provide the following for your BibTex:
 
 ```
-@misc{Randall2024,
-  title = {{scikit-SUNDAE: Python bindings to SUNDIALS DAE solvers}},
+@misc{Randall-2024,
+  title = {{scikit-SUNDAE ((SUN)DIALS Differential Algebraic Equations) [SWR-24-137]}},
   author = {Randall, Corey R.},
-  year = {2024},
-  doi = {placeholder... waiting for DOI},
+  doi = {10.11578/dc.20241104.3},
   url = {https://github.com/NREL/scikit-sundae},
+  year = {2024},
 }
 ```
 

--- a/docs/source/_templates/copyright.html
+++ b/docs/source/_templates/copyright.html
@@ -1,0 +1,12 @@
+{# Displays the copyright information (which is defined in conf.py). #}
+{% if show_copyright and copyright %}
+  <p class="copyright">
+    {% if hasdoc('copyright') %}
+      © <a href="{{ pathto('copyright') }}">{% trans copyright=copyright|e %}Copyright {{ copyright }}{% endtrans %}</a>.
+      <br/>
+    {% else %}
+      {% trans copyright=copyright|e %}© {{ copyright }}.{% endtrans %}
+      <br/>
+    {% endif %}
+  </p>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 import sksundae as sun
 
 project = 'scikit-sundae'
-copyright = '2024, Corey R. Randall'
+copyright = 'Alliance for Sustainable Energy, LLC'
 author = 'Corey R. Randall'
 version = sun.__version__
 release = sun.__version__

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -2,4 +2,4 @@ name: sun
 channels:
   - conda-forge
 dependencies:
-  - sundials=7.1
+  - sundials=7.2

--- a/environments/rtd_environment.yml
+++ b/environments/rtd_environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.12
-  - sundials=7.1
+  - sundials=7.2
   - pip>=24.3
   - pip:
     - ../.[docs]

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 29">
-	<title>tests: 29</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 31">
+	<title>tests: 31</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">29</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">29</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">31</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">31</text>
 	</g>
 </svg>

--- a/scripts/version_checker.py
+++ b/scripts/version_checker.py
@@ -1,0 +1,132 @@
+import requests
+import argparse
+from packaging.version import Version
+
+
+def get_latest_version(package: str, prefix: str = None) -> str:
+    """
+    Fetch the latest version with matching prefix from PyPI.
+
+    Parameters
+    ----------
+    package : str
+        The name of the package to query.
+    prefix : str
+        A filtering prefix used to get a subset of releases, e.g., '1.1' will
+        return the latest patch to version 1.1 even if 1.2 exists.
+
+    Returns
+    -------
+    latest_version : str
+        The latest version available on PyPI. '0.0.0' is returned if there
+        are no versions.
+
+    Raises
+    ------
+    ValueError
+        Failed to fetch PyPI data for requested package.
+
+    """
+
+    url = f"https://pypi.org/pypi/{package}/json"
+
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ValueError(f"Failed to fetch PyPI data for '{package}'.")
+
+    data = response.json()
+    versions = list(data['releases'].keys())
+    if not versions:
+        print(f"{package=} not found on PyPI.")
+        return '0.0.0'
+
+    if prefix:
+        versions = [v for v in versions if v.startswith(prefix)]
+        assert len(versions) != 0, f"{prefix=} has no existing matches."
+
+    sorted_versions = sorted(versions, key=Version, reverse=True)
+    latest_version = sorted_versions[0]
+
+    print(f"Latest PyPI version for {package}: {latest_version}.")
+    return latest_version
+
+
+def check_against_pypi(pypi: str, local: str) -> None:
+    """
+    Verify the local version is newer than PyPI.
+
+    Parameters
+    ----------
+    pypi : str
+        Latest version on PyPI.
+    local : str
+        Local package version.
+
+    Returns
+    -------
+    None.
+
+    Raises
+    ------
+    ValueError
+        Local package is older than PyPI.
+
+    """
+
+    pypi = Version(pypi)
+    local = Version(local)
+
+    if local < pypi:
+        raise ValueError(f"Local package {local} is older than PyPI {pypi}.")
+
+    print(f"Local package {local} is newer than PyPI {pypi}.")
+
+
+def check_against_tag(tag: str, local: str) -> None:
+    """
+    Check that the tag matches the package version.
+
+    Parameters
+    ----------
+    tag : str
+        Semmantically versioned tag.
+    local : str
+        Local package version.
+
+    Returns
+    -------
+    None.
+
+    Raises
+    ------
+    ValueError
+        Version mismatch: tag differs from local.
+
+    """
+
+    tag = Version(tag)
+    local = Version(local)
+
+    if tag != local:
+        raise ValueError(f"Version mismatch: {tag=} vs. {local=}")
+
+    print(f"Local and tag versions match: {tag} == {local}.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--tag', required=True)
+    parser.add_argument('--local', required=True)
+    args = parser.parse_args()
+
+    check_against_tag(args.tag, args.local)
+
+    patch_check = Version(args.local)
+    if patch_check.micro > 0:
+        prefix = str(patch_check.major) + '.' + str(patch_check.minor)
+    else:
+        prefix = None
+
+    pypi = get_latest_version('scikit-sundae', prefix)
+
+    check_against_pypi(pypi, args.local)

--- a/src/sksundae/__init__.py
+++ b/src/sksundae/__init__.py
@@ -61,4 +61,4 @@ from . import cvode
 
 __all__ = ['ida', 'utils', 'cvode', 'SUNDIALS_VERSION']
 
-__version__ = '1.0.0rc3'
+__version__ = '1.0.0'

--- a/src/sksundae/_cy_common.pxd
+++ b/src/sksundae/_cy_common.pxd
@@ -4,7 +4,7 @@
 cimport numpy as np
 
 # Extern cdef headers
-from .c_sundials cimport *  # Access to types
+from .c_sundials cimport *  # Access to C types
 
 # Convert between N_Vector and numpy array
 cdef svec2np(N_Vector nvec, np.ndarray[DTYPE_t, ndim=1] np_array)

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -12,7 +12,7 @@ from typing import Callable, Iterable
 # Dependencies
 import numpy as np
 cimport numpy as np
-from cpython.exc cimport PyErr_CheckSignals
+from cpython.exc cimport PyErr_CheckSignals, PyErr_Occurred
 
 # Extern cdef headers
 from .c_cvode cimport *
@@ -146,7 +146,8 @@ cdef void _err_handler(int line, const char* func, const char* file,
     decoded_func = func.decode("utf-8")
     decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
 
-    print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
+    if not PyErr_Occurred():
+        print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
 
 
 cdef class AuxData:

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -83,7 +83,7 @@ LSMESSAGES = {
 
 
 cdef int _rhsfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp,
-                        void* data) noexcept:
+                        void* data) except? -1:
     """Wraps 'rhsfn' by converting between N_Vector and ndarray types."""
 
     aux = <AuxData> data
@@ -101,7 +101,7 @@ cdef int _rhsfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp,
 
 
 cdef int _eventsfn_wrapper(sunrealtype t, N_Vector yy, sunrealtype* ee,
-                           void* data) noexcept:
+                           void* data) except? -1:
     """Wraps 'eventsfn' by converting between N_Vector and ndarray types."""
 
     aux = <AuxData> data
@@ -120,7 +120,7 @@ cdef int _eventsfn_wrapper(sunrealtype t, N_Vector yy, sunrealtype* ee,
 
 cdef int _jacfn_wrapper(sunrealtype t, N_Vector yy, N_Vector fy, SUNMatrix JJ,
                         void* data, N_Vector tmp1, N_Vector tmp2,
-                        N_Vector tmp3) noexcept:
+                        N_Vector tmp3) except? -1:
     """Wraps 'jacfn' by converting between N_Vector and ndarray types."""
     
     aux = <AuxData> data
@@ -140,7 +140,7 @@ cdef int _jacfn_wrapper(sunrealtype t, N_Vector yy, N_Vector fy, SUNMatrix JJ,
 
 cdef void _err_handler(int line, const char* func, const char* file,
                        const char* msg, int err_code, void* err_user_data,
-                       SUNContext ctx) noexcept:
+                       SUNContext ctx) except *:
     """Custom error handler for shorter messages (no line or file)."""
     
     decoded_func = func.decode("utf-8")

--- a/src/sksundae/_cy_ida.pyx
+++ b/src/sksundae/_cy_ida.pyx
@@ -81,7 +81,7 @@ LSMESSAGES = {
 
 
 cdef int _resfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr,
-                        void* data) noexcept:
+                        void* data) except? -1:
     """Wraps 'resfn' by converting between N_Vector and ndarray types."""
 
     aux = <AuxData> data
@@ -100,7 +100,7 @@ cdef int _resfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr,
 
 
 cdef int _eventsfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp,
-                           sunrealtype* ee, void* data) noexcept:
+                           sunrealtype* ee, void* data) except? -1:
     """Wraps 'eventsfn' by converting between N_Vector and ndarray types."""
 
     aux = <AuxData> data
@@ -120,7 +120,7 @@ cdef int _eventsfn_wrapper(sunrealtype t, N_Vector yy, N_Vector yp,
 
 cdef int _jacfn_wrapper(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp,
                         N_Vector rr, SUNMatrix JJ, void* data, N_Vector tmp1,
-                        N_Vector tmp2, N_Vector tmp3) noexcept:
+                        N_Vector tmp2, N_Vector tmp3) except? -1:
     """Wraps 'jacfn' by converting between N_Vector and ndarray types."""
     
     aux = <AuxData> data
@@ -142,7 +142,7 @@ cdef int _jacfn_wrapper(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp,
 
 cdef void _err_handler(int line, const char* func, const char* file,
                        const char* msg, int err_code, void* err_user_data,
-                       SUNContext ctx) noexcept:
+                       SUNContext ctx) except *:
     """Custom error handler for shorter messages (no line or file)."""
     
     decoded_func = func.decode("utf-8")

--- a/src/sksundae/_cy_ida.pyx
+++ b/src/sksundae/_cy_ida.pyx
@@ -12,7 +12,7 @@ from typing import Callable, Iterable
 # Dependencies
 import numpy as np
 cimport numpy as np
-from cpython.exc cimport PyErr_CheckSignals
+from cpython.exc cimport PyErr_CheckSignals, PyErr_Occurred
 
 # Extern cdef headers
 from .c_ida cimport *
@@ -148,7 +148,8 @@ cdef void _err_handler(int line, const char* func, const char* file,
     decoded_func = func.decode("utf-8")
     decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
 
-    print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
+    if not PyErr_Occurred():
+        print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
 
 
 cdef class AuxData:

--- a/src/sksundae/c_cvode.pxd
+++ b/src/sksundae/c_cvode.pxd
@@ -6,8 +6,8 @@ from .c_sundials cimport *  # Access to types
 cdef extern from "cvode/cvode.h":
 
     # user-supplied functions
-    ctypedef int (*CVRhsFn)(sunrealtype t, N_Vector yy, N_Vector yp, void* data)
-    ctypedef int (*CVRootFn)(sunrealtype t, N_Vector yy, sunrealtype* ee, void* data)
+    ctypedef int (*CVRhsFn)(sunrealtype t, N_Vector yy, N_Vector yp, void* data) except? -1
+    ctypedef int (*CVRootFn)(sunrealtype t, N_Vector yy, sunrealtype* ee, void* data) except? -1
 
     # imethod
     int CV_ADAMS
@@ -66,8 +66,8 @@ cdef extern from "cvode/cvode.h":
 cdef extern from "cvode/cvode_ls.h":
 
     # user-supplied functions
-    ctypedef int (*CVLsJacFn)(sunrealtype t, N_Vector yy, N_Vector fy, SUNMatrix JJ,
-                              void* data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3)
+    ctypedef int (*CVLsJacFn)(sunrealtype t, N_Vector yy, N_Vector fy, SUNMatrix JJ, void* data,
+                              N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except? -1
 
     # exported functions
     int CVodeSetLinearSolver(void* mem, SUNLinearSolver LS, SUNMatrix A)

--- a/src/sksundae/c_ida.pxd
+++ b/src/sksundae/c_ida.pxd
@@ -6,8 +6,8 @@ from .c_sundials cimport *
 cdef extern from "ida/ida.h":
 
     # user-supplied functions
-    ctypedef int (*IDAResFn)(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* data)
-    ctypedef int (*IDARootFn)(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype* ee, void* data)
+    ctypedef int (*IDAResFn)(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* data) except? -1
+    ctypedef int (*IDARootFn)(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype* ee, void* data) except? -1
 
     # itask
     int IDA_NORMAL
@@ -73,7 +73,7 @@ cdef extern from "ida/ida_ls.h":
     # user-supplied functions
     ctypedef int (*IDALsJacFn)(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp,
                                N_Vector rr, SUNMatrix JJ, void* data, N_Vector tmp1,
-                               N_Vector tmp2, N_Vector tmp3)
+                               N_Vector tmp2, N_Vector tmp3) except? -1
 
     # exported functions
     int IDASetLinearSolver(void* mem, SUNLinearSolver LS, SUNMatrix A)

--- a/src/sksundae/c_sundials.pxd
+++ b/src/sksundae/c_sundials.pxd
@@ -35,7 +35,7 @@ cdef extern from "sundials/sundials_types.h":
     ctypedef int SUNComm
     ctypedef void (*SUNErrHandlerFn)(int line, const char* func, const char* file,
                                      const char* msg, int err_code, void* err_user_data,
-                                     SUNContext ctx)
+                                     SUNContext ctx) except *
 
     int SUN_COMM_NULL
 

--- a/tests/test_cvode.py
+++ b/tests/test_cvode.py
@@ -199,6 +199,54 @@ def test_cvode_jacfn():
     assert np.allclose(soln.y, ode_soln(soln.t, y0))
 
 
+def test_failures_on_exceptions():
+
+    # exception in rhsfn
+    def bad_ode(t, y, yp):
+        if t > 1:
+            raise ValueError()
+
+        yp[0] = 0.1
+        yp[1] = y[1]
+
+    y0 = np.array([1, 2])
+
+    solver = CVODE(bad_ode, rtol=1e-9, atol=1e-12)
+
+    with pytest.raises(ValueError):
+        tspan = np.linspace(0, 10, 11)
+        soln = solver.solve(tspan, y0)
+        assert soln.status < 0
+
+    # exceptions in eventsfn
+    def eventsfn(t, y, events):
+        if t > 1:
+            raise ValueError()
+
+        events[0] = y[0] - 1.55
+
+    solver = CVODE(ode, rtol=1e-9, atol=1e-12, eventsfn=eventsfn, num_events=1)
+
+    with pytest.raises(ValueError):
+        tspan = np.linspace(0, 10, 11)
+        soln = solver.solve(tspan, y0)
+        assert soln.status < 0
+
+    # exceptions in jacfn
+    def jacfn(t, y, fy, JJ):
+        if t > 1:
+            raise ValueError()
+
+        JJ[1, 1] = 1
+
+    solver = CVODE(ode, rtol=1e-9, atol=1e-12, jacfn=jacfn)
+
+    with pytest.raises(ValueError):
+        tspan = np.linspace(0, 10, 11)
+        soln = solver.solve(tspan, y0)
+        assert soln.status < 0
+
+
 def test_CVODEResult():
     y0 = np.array([1, 2])
 

--- a/tests/test_cvode.py
+++ b/tests/test_cvode.py
@@ -204,7 +204,7 @@ def test_failures_on_exceptions():
     # exception in rhsfn
     def bad_ode(t, y, yp):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         yp[0] = 0.1
         yp[1] = y[1]
@@ -213,38 +213,35 @@ def test_failures_on_exceptions():
 
     solver = CVODE(bad_ode, rtol=1e-9, atol=1e-12)
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0)
 
     # exceptions in eventsfn
     def eventsfn(t, y, events):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         events[0] = y[0] - 1.55
 
     solver = CVODE(ode, rtol=1e-9, atol=1e-12, eventsfn=eventsfn, num_events=1)
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0)
 
     # exceptions in jacfn
     def jacfn(t, y, fy, JJ):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         JJ[1, 1] = 1
 
     solver = CVODE(ode, rtol=1e-9, atol=1e-12, jacfn=jacfn)
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0)
 
 
 def test_CVODEResult():

--- a/tests/test_ida.py
+++ b/tests/test_ida.py
@@ -300,7 +300,7 @@ def test_failures_on_exceptions():
     # exception in resfn
     def bad_dae(t, y, yp, res):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         res[0] = yp[0] - 0.1
         res[1] = 2*y[0] - y[1]
@@ -310,30 +310,28 @@ def test_failures_on_exceptions():
 
     solver = IDA(bad_dae, rtol=1e-9, atol=1e-12, algebraic_idx=[1])
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0, yp0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0, yp0)
 
     # exceptions in eventsfn
     def eventsfn(t, y, yp, events):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         events[0] = y[0] - 1.55
 
     solver = IDA(dae, rtol=1e-9, atol=1e-12, algebraic_idx=[1],
                  eventsfn=eventsfn, num_events=1)
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0, yp0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0, yp0)
 
     # exceptions in jacfn
     def jacfn(t, y, yp, res, cj, JJ):
         if t > 1:
-            raise ValueError()
+            raise ValueError("propagated exception")
 
         JJ[0, 0] = cj
         JJ[1, 0] = 2
@@ -342,10 +340,9 @@ def test_failures_on_exceptions():
     solver = IDA(dae, rtol=1e-9, atol=1e-12, algebraic_idx=[1],
                  jacfn=jacfn)
 
-    with pytest.raises(ValueError):
-        tspan = np.linspace(0, 10, 11)
-        soln = solver.solve(tspan, y0, yp0)
-        assert soln.status < 0
+    tspan = np.linspace(0, 10, 11)
+    with pytest.raises(ValueError, match='propagated exception'):
+        _ = solver.solve(tspan, y0, yp0)
 
 
 def test_IDAResult():


### PR DESCRIPTION
# Description
Python exceptions were unable to propagate through Cython functions. This is now fixed by using Cython's `except? -1` and `except *` on all Python function wrappers and on the custom SUNDIALS error handler.  

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
