### PR TITLE
Fixed source/dev installation instruction typos in docs

### DIFF
--- a/docs/source/development/development_environments.rst
+++ b/docs/source/development/development_environments.rst
@@ -18,11 +18,11 @@ This guide will walk you through setting up a local development environment for 
 2. Create a virtual environment
     Since we build scikit-SUNDAE agasint SUNDIALS releases on conda-forge, you will need to set up a virtual environment with ``conda`` access. While there are a few options you can use, we recommend using `Anaconda <https://anaconda.org>`_. With Anaconda installed, open the terminal (MacOS/Linux) or Anaconda Prompt and run::
 
-        conda install python=x.x sundials=x.x -c conda-forge
+        conda create -n sun -c conda-forge python=x.x sundials=x.x
 
-    The ``x.x`` version numbers should be filled in with the latest stable releases of Python and SUNDIALS. Continuous Integration (CI) workflows automatically test older versions. 
+    The ``x.x`` version numbers should be filled in with the latest stable releases of Python and SUNDIALS. Continuous Integration (CI) workflows automatically test older Python versions. 
     
-    On occasion, if issues arise during tests, you may need to work with older Python versions temporarily. In these cases, please reference the table on the main :doc:`/user_guide/installation` page to verify which SUNDIALS versions are compatible.
+    On occasion, you may need to work with older Python and/or SUNDIALS versions (e.g., patching old versions, or resolving version-specific CI failures). In cases where you are not working with the latest version of scikit-SUNDAE, please reference the table on the main :doc:`/user_guide/installation` page to verify SUNDIALS compatibilities.
 
 3. Set the ``SUNDIALS_PREFIX`` environment variable
     scikit-SUNDAE expects your SUNDIALS installation to be in either ``$CONDA_PREFIX`` or ``%CONDA_PREFIX%\Library``. Check to see if your installation is in either of these directories. If it isn't, you will need to set the ``SUNDIALS_PREFIX`` environment variable::

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -114,15 +114,15 @@ scikit-SUNDAE Version  Supported SUNDIALS Version(s)
     xcode-select --install      (for MacOS)
     sudo apt install clang      (for Linux)
 
-2. Skip to step (2) if you are trying to compile against a custom SUNDIALS build. Otherwise, install a supported SUNDIALS release from conda-forge. Reference the table above to find a version that is compatible with the version of scikit-SUNDAE you are trying to install, and fill in the ``x.x`` below with an appropriate version::
+2. Skip to step (3) if you are trying to compile against a custom SUNDIALS build. Otherwise, install a supported SUNDIALS release from conda-forge. Reference the table above to find a version that is compatible with the version of scikit-SUNDAE you are trying to install, and fill in the ``x.x`` below with an appropriate version::
 
     conda install -c conda-forge sundials=x.x 
 
-3. Skip this step if you installed SUNDIALS from conda-forge during step (1). Otherwise, make sure your SUNDIALS version is compatible with the version of scikit-SUNDAE you're trying to install using the table above as a reference. Afterward, find the parent directory for your SUNDIALS files and follow the directions in the :ref:`Cannot Locate SUNDIALS` section to set the ``SUNDIALS_PREFIX`` environment variable.
+3. Skip this step if you installed SUNDIALS from conda-forge during step (2). Otherwise, make sure your SUNDIALS version is compatible with the version of scikit-SUNDAE you're trying to install using the table above as a reference. Afterward, find the parent directory for your SUNDIALS files and follow the directions in the :ref:`Cannot Locate SUNDIALS` section to set the ``SUNDIALS_PREFIX`` environment variable.
 
-4. Force the package to install the source distribution from PyPI:: 
+4. Force the package to install the source distribution from PyPI, with the verbose option:: 
 
-    pip install --no-binary scikit-sundae scikit-sundae <other packages>
+    pip install scikit-sundae --no-binary scikit-sundae -v
 
 .. _Visual Studio: https://visualstudio.microsoft.com/
 .. _Clang: https://clang.llvm.org/


### PR DESCRIPTION
# Description
Simply fixes a couple typos in the documentation regaurding installation instructions from source and for the dev version.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
