### PR TITLE
Optimizations for Cython build and numpy API interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Optimizations
 - Use `micromamba` instead of `miniconda` in CI ([PR #3](https://github.com/NREL/scikit-sundae/pull/3))
-- Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([PR # 5](https://github.com/NREL/scikit-sundae/pull/5))
+- Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([PR #5](https://github.com/NREL/scikit-sundae/pull/5))
 - Replace loops that write data between 1D numpy arrays and SUNDIALS NVectors in favor of single-line memory views with pointer addressing ([PR #5](https://github.com/NREL/scikit-sundae/pull/5))
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### Optimizations
 - Use `micromamba` instead of `miniconda` in CI ([PR #3](https://github.com/NREL/scikit-sundae/pull/3))
-- Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([PR # 4](https://github.com/NREL/scikit-sundae/pull/3))
-- Replace loops that write data between 1D numpy arrays and SUNDIALS NVectors in favor of single-line memory views with pointer addressing ([PR #4](https://github.com/NREL/scikit-sundae/pull/3))
+- Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([PR # 5](https://github.com/NREL/scikit-sundae/pull/5))
+- Replace loops that write data between 1D numpy arrays and SUNDIALS NVectors in favor of single-line memory views with pointer addressing ([PR #5](https://github.com/NREL/scikit-sundae/pull/5))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Optimizations
 - Use `micromamba` instead of `miniconda` in CI ([PR #3](https://github.com/NREL/scikit-sundae/pull/3))
+- Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([PR # 4](https://github.com/NREL/scikit-sundae/pull/3))
+- Replace loops that write data between 1D numpy arrays and SUNDIALS NVectors in favor of single-line memory views with pointer addressing ([PR #4](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Bug Fixes
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import importlib
 
 import nox
 
@@ -89,10 +90,13 @@ def run_pytest(session: nox.Session) -> None:
 
     """
 
+    package = importlib.util.find_spec('sksundae')
+    coverage_folder = os.path.dirname(package.origin)
+
     if 'no-reports' in session.posargs:
         command = [
             'pytest',
-            '--cov=src/sksundae',
+            f'--cov={coverage_folder}',  # for editable or site-packages
             'tests/',
         ]
     else:

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ def get_extensions():
             include_dirs=SUNDIALS_INCLUDE_DIRS,
             library_dirs=SUNDIALS_LIBRARY_DIRS,
             libraries=LIBRARIES,
-            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+            define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
         ),
         setuptools.Extension(
             name='sksundae._cy_cvode',
@@ -147,7 +147,7 @@ def get_extensions():
             include_dirs=SUNDIALS_INCLUDE_DIRS,
             library_dirs=SUNDIALS_LIBRARY_DIRS,
             libraries=LIBRARIES + ['sundials_cvode'],
-            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+            define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
         ),
         setuptools.Extension(
             name='sksundae._cy_ida',
@@ -155,7 +155,7 @@ def get_extensions():
             include_dirs=SUNDIALS_INCLUDE_DIRS,
             library_dirs=SUNDIALS_LIBRARY_DIRS,
             libraries=LIBRARIES + ['sundials_ida'],
-            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+            define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
         ),
     ]
 

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -170,7 +170,7 @@ cdef class AuxData:
     cdef object eventsfn
     cdef object jacfn
 
-    def __cinit__(self, np.npy_intp NEQ, object options):
+    def __cinit__(self, sunindextype NEQ, object options):
         self.np_yy = np.empty(NEQ, DTYPE)
         self.np_yp = np.empty(NEQ, DTYPE)
         self.np_fy = np.empty(NEQ, DTYPE)
@@ -203,7 +203,7 @@ cdef class CVODE:
     cdef N_Vector yy
     cdef SUNMatrix A 
     cdef SUNLinearSolver LS
-    cdef np.npy_intp NEQ
+    cdef sunindextype NEQ
     cdef AuxData aux
 
     cdef object _options
@@ -312,7 +312,7 @@ cdef class CVODE:
         # 3) Set problem dimensions
         
         # 4) Create vectors of initial values        
-        self.NEQ = y0.size
+        self.NEQ = <sunindextype> y0.size
         self.aux = AuxData(self.NEQ, self._options)
 
         self.yy = N_VNew_Serial(self.NEQ, self.ctx)

--- a/src/sksundae/_cy_ida.pyx
+++ b/src/sksundae/_cy_ida.pyx
@@ -172,7 +172,7 @@ cdef class AuxData:
     cdef object eventsfn
     cdef object jacfn
 
-    def __cinit__(self, np.npy_intp NEQ, object options):
+    def __cinit__(self, sunindextype NEQ, object options):
         self.np_yy = np.empty(NEQ, DTYPE)
         self.np_yp = np.empty(NEQ, DTYPE)
         self.np_rr = np.empty(NEQ, DTYPE)
@@ -206,7 +206,7 @@ cdef class IDA:
     cdef N_Vector yp
     cdef SUNMatrix A 
     cdef SUNLinearSolver LS
-    cdef np.npy_intp NEQ
+    cdef sunindextype NEQ
     cdef AuxData aux
 
     cdef object _options
@@ -317,7 +317,7 @@ cdef class IDA:
         if len(y0) != len(yp0):
             raise ValueError("'y0' and 'yp0' must be the same size.")
         
-        self.NEQ = y0.size
+        self.NEQ = <sunindextype> y0.size
         self.aux = AuxData(self.NEQ, self._options)
 
         self.yy = N_VNew_Serial(self.NEQ, self.ctx)

--- a/src/sksundae/c_sundials.pxd
+++ b/src/sksundae/c_sundials.pxd
@@ -4,28 +4,11 @@
 cimport numpy as np
 
 # Define float and int types:
-# config.pxi is created in setup.py. While building the python package, the 
+# c_config.pxi is created in setup.py. While building the python package, the 
 # sundials_config.h header is parsed to determine what precision was used to
 # compile the SUNDIALS that is being built against. The settings are saved in
 # the pxi file and used here.
-include "config.pxi"
-
-IF SUNDIALS_FLOAT_TYPE == "single":
-    ctypedef float sunrealtype
-    ctypedef np.float32_t DTYPE_t
-ELIF SUNDIALS_FLOAT_TYPE == "double":
-    ctypedef double sunrealtype
-    ctypedef np.float64_t DTYPE_t
-ELIF SUNDIALS_FLOAT_TYPE == "extended":
-    ctypedef long double sunrealtype
-    ctypedef np.float128_t DTYPE_t
-
-IF SUNDIALS_INT_TYPE == "int32":
-    ctypedef int sunindextype
-    ctypedef np.int32_t INT_TYPE_t
-ELIF SUNDIALS_INT_TYPE == "int64":
-    ctypedef long int sunindextype
-    ctypedef np.int64_t INT_TYPE_t
+include "c_config.pxi"
 
 # sundials_types.h
 cdef extern from "sundials/sundials_types.h":


### PR DESCRIPTION
# Description
Cython has plans to deprecate its `IF/ELIF/ELSE` and `DEF` syntax. While the timing for this is unknown and they are committed to supporting these until a reasonable replacement is proposed, it is not too difficult to remove them now.

In addition, a couple small changes were made with respect to how the code interfaces with the numpy C API. In particular, the macro `NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION` was added to the `setup.py` builds for each extension to avoid warnings. Also, the `np2ptr` and `ptr2np` functions were updated to remove loops. This negligibly improves performance for most small problems, but should benefit very large problems.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
