### PR TITLE
Bugfix/j pattern

### DIFF
--- a/src/sksundae/__init__.py
+++ b/src/sksundae/__init__.py
@@ -38,7 +38,7 @@ a separate, independent package. During development we prioritized:
 1. Using scipy-like output containers
 2. Adopting event function APIs like `scipy.integrate`_, with a few exceptions
 3. Maintaining and testing builds using SUNDIALS releases on `conda-forge`_
-4. Setuping the package for binary distribution
+4. Setting up the package for binary distribution
 
 Since scikit-SUNDAE installations may include pre-built SUNDIALS libraries, a
 `bundled license file`_ is included with all distributions. The bundled license

--- a/src/sksundae/jacband.py
+++ b/src/sksundae/jacband.py
@@ -35,7 +35,8 @@ def _cvode_pattern(rhsfn: Callable, t0: float, y0: ndarray,
     srur = np.sqrt(uround)
 
     # perturbed variables
-    y = np.maximum(srur, y0)
+    sign_y = (y0 >= 0).astype(float) * 2 - 1
+    y = sign_y * np.maximum(uround, np.abs(y0))
 
     # initial derivatives
     yp_0 = np.zeros_like(y)
@@ -88,8 +89,11 @@ def _ida_pattern(resfn: Callable, t0: float, y0: ndarray, yp0: ndarray = None,
     srur = np.sqrt(uround)
 
     # perturbed variables
-    y = np.maximum(srur, y0)
-    yp = np.maximum(srur, yp0)
+    sign_y = (y0 >= 0).astype(float) * 2 - 1
+    y = sign_y * np.maximum(uround, np.abs(y0))
+
+    sign_yp = (yp0 >= 0).astype(float) * 2 - 1
+    yp = sign_yp * np.maximum(uround, np.abs(yp0))
 
     # initial residuals
     res_0 = np.zeros_like(y)

--- a/src/sksundae/jacband.py
+++ b/src/sksundae/jacband.py
@@ -1,4 +1,4 @@
-# mstructs.py
+# jacband.py
 
 from __future__ import annotations
 from typing import Callable, Any, TYPE_CHECKING
@@ -31,7 +31,8 @@ def _cvode_pattern(rhsfn: Callable, t0: float, y0: ndarray,
         raise ValueError("'rhsfn' signature must have either 3 or 4 inputs.")
 
     # recommended minimum perturbation
-    uround = np.finfo(y0.dtype).eps
+    dtype = y0.dtype if np.issubdtype(y0.dtype, np.floating) else np.float64
+    uround = np.finfo(dtype).eps
     srur = np.sqrt(uround)
 
     # perturbed variables
@@ -85,7 +86,8 @@ def _ida_pattern(resfn: Callable, t0: float, y0: ndarray, yp0: ndarray = None,
         raise ValueError("'rhsfn' signature must have either 4 or 5 inputs.")
 
     # recommended minimum perturbation
-    uround = np.finfo(y0.dtype).eps
+    dtype = y0.dtype if np.issubdtype(y0.dtype, np.floating) else np.float64
+    uround = np.finfo(dtype).eps
     srur = np.sqrt(uround)
 
     # perturbed variables


### PR DESCRIPTION
# Description
Fixes a bug from the new `j_pattern` routines. First, using `np.maximum` to neglect zeros was also overwriting negatives. Adding `sign_y` terms fixed this. Second, the `eps` value was exclusively based on `y0`, which may be given as an array of integers and therefore be incompatible with `finfo`. Now `eps` is taken from `y0` info if it is an array of floating point numbers, otherwise, `np.float64` is used as the default.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
