### PR TITLE
Add support for np float/int types in options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## [Unreleased](https://github.com/NREL/scikit-sundae/)
 
 ### New Features
+- Allow `numpy` types in options checks for both `CVODE` and `IDA` ([#8](https://github.com/NREL/scikit-sundae/pull/8))
 - Expose linear solver option that uses SuperLU_MT ([#6](https://github.com/NREL/scikit-sundae/pull/6))
 - New `jacband` module for support finding sparsity/bandwidth ([#6](https://github.com/NREL/scikit-sundae/pull/6))
 - Custom `sparseDQJac` routines available by supplying `sparsity` ([#6](https://github.com/NREL/scikit-sundae/pull/6))
 - Changed signature inspections to support decorated `jit` functions ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Optimizations
-- Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 - Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([#5](https://github.com/NREL/scikit-sundae/pull/5))
-- Replace loops that write data between 1D numpy arrays and SUNDIALS NVectors in favor of single-line memory views with pointer addressing ([#5](https://github.com/NREL/scikit-sundae/pull/5))
+- Replace loops between 1D numpy arrays and SUNDIALS NVectors with single-line memory views and pointer addressing ([#5](https://github.com/NREL/scikit-sundae/pull/5))
+- Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Bug Fixes
 - Add `sign_y` terms and default to `np.float64` for floating type in `j_pattern` ([#7](https://github.com/NREL/scikit-sundae/pull/7))

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -8,7 +8,7 @@ import os
 import inspect
 
 from warnings import warn
-from types import MethodType
+from numbers import Integral, Real
 from typing import Callable, Iterable
 
 # Dependencies
@@ -369,8 +369,8 @@ cdef class CVODE:
             self.LS = SUNLinSol_Dense(self.yy, self.A, self.ctx)
 
         elif self._options["linsolver"].lower() == "band":
-            uband = self._options["uband"]
-            lband = self._options["lband"]
+            uband = <int> self._options["uband"]
+            lband = <int> self._options["lband"]
 
             self.A = SUNBandMatrix(self.NEQ, uband, lband, self.ctx)
             self.LS = SUNLinSol_Band(self.yy, self.A, self.ctx)
@@ -584,7 +584,7 @@ cdef class CVODE:
         elif method == "onestep":  # output after one internal step toward tt
             itask = CV_ONE_STEP
 
-        if isinstance(tstop, (int, float)):
+        if isinstance(tstop, Real):
             flag = CVodeSetStopTime(self.mem, <sunrealtype> tstop)
             if flag < 0:
                 raise RuntimeError("CVodeSetStopTime - " + CVMESSAGES[flag])
@@ -795,7 +795,7 @@ cdef class CVODE:
 
         if tstop is None:
             pass
-        elif not isinstance(tstop, (int, float)):
+        elif not isinstance(tstop, Real):
             raise TypeError("'tstop' must be type float, or None.")
         
         return self._step(t, method, tstop)
@@ -848,7 +848,7 @@ cdef _prepare_events(object eventsfn, int num_events):
     terminal = eventsfn.terminal
     if not isinstance(terminal, Iterable):
         raise TypeError("'eventsfn.terminal' must be type Iterable.")
-    elif not all(isinstance(x, (bool, int)) for x in terminal):
+    elif not all(isinstance(x, (bool, Integral)) for x in terminal):
         raise TypeError("All 'eventsfn.terminal' values must be bool or int.")
     elif not all(int(x) >= 0 for x in terminal):
         raise ValueError("At least one 'eventsfn.terminal' value is invalid."
@@ -992,19 +992,19 @@ def _check_options(options: dict) -> None:
         raise ValueError(f"{method=} is invalid. Must be in {valid}.")
     
     # first_step
-    if not isinstance(options["first_step"], (int, float)):
+    if not isinstance(options["first_step"], Real):
         raise TypeError("'first_step' must be type float.")
     elif options["first_step"] < 0.:
         raise ValueError("'first_step' must be positive or zero.")
         
     # min_step
-    if not isinstance(options["min_step"], (int, float)):
+    if not isinstance(options["min_step"], Real):
         raise TypeError("'min_step' must be type float.")
     elif options["min_step"] < 0.:
         raise ValueError("'min_step' must be positive or zero.")
 
     # max_step
-    if not isinstance(options["max_step"], (int, float)):
+    if not isinstance(options["max_step"], Real):
         raise TypeError("'max_step' must be type float.")
     elif options["max_step"] < 0.:
         raise ValueError("'max_step' must be positive or zero.")
@@ -1012,12 +1012,16 @@ def _check_options(options: dict) -> None:
         raise ValueError("'max_step' cannot be smaller than 'min_step'.")
 
     # rtol
-    if not isinstance(options["rtol"], float):
+    if not isinstance(options["rtol"], Real):
         raise TypeError("'rtol' must be type float.")
 
     # atol
-    if not isinstance(options["atol"], (float, Iterable)):
-        raise TypeError("'atol' must be type float or Iterable.")
+    if isinstance(options["atol"], Real):
+        pass
+    elif not isinstance(options["atol"], Iterable):
+        raise TypeError("'atol' must be type float or Iterable[float].")
+    elif not all(isinstance(x, Real) for x in options["atol"]):
+        raise TypeError("When iterable, all 'atol' values must be float.")
 
     # linsolver
     valid =  {"dense", "band", "sparse"}
@@ -1034,7 +1038,7 @@ def _check_options(options: dict) -> None:
     lband = options["lband"]
     if lband is None:
         pass
-    elif not isinstance(lband, int):
+    elif not isinstance(lband, Integral):
         raise TypeError("'lband' must be type int.")
     elif lband < 0:
         raise ValueError("'lband' must be positive or zero.")
@@ -1043,7 +1047,7 @@ def _check_options(options: dict) -> None:
     uband = options["uband"]
     if uband is None:
         pass
-    elif not isinstance(uband, int):
+    elif not isinstance(uband, Integral):
         raise TypeError("'uband' must be type int.")
     elif uband < 0:
         raise ValueError("'uband' must be positive or zero.")
@@ -1077,7 +1081,7 @@ def _check_options(options: dict) -> None:
             nthreads = 1
         elif nthreads <= -1 or nthreads > ncpu_cores:
             nthreads = ncpu_cores
-        elif not isinstance(nthreads, int):
+        elif not isinstance(nthreads, Integral):
             raise TypeError("'nthreads' must be type int.")
 
         options["nthreads"] = nthreads  # save defaults update, if done
@@ -1101,25 +1105,25 @@ def _check_options(options: dict) -> None:
     elif method == "adams":
         max_allowed = 12
 
-    if not isinstance(options["max_order"], int):
+    if not isinstance(options["max_order"], Integral):
         raise TypeError("'max_order' must be type int.")
     elif options["max_order"] < 1 or options["max_order"] > max_allowed:
         raise ValueError(f"'max_order' must be in range [1, {max_allowed}].")
 
     # max_num_steps
-    if not isinstance(options["max_num_steps"], int):
+    if not isinstance(options["max_num_steps"], Integral):
         raise TypeError("'max_num_steps' must be type int.")
     elif not options["max_num_steps"] > 0:
         raise ValueError("'max_num_steps' must be > 0.")
 
     # max_nonlin_iters
-    if not isinstance(options["max_nonlin_iters"], int):
+    if not isinstance(options["max_nonlin_iters"], Integral):
         raise TypeError("'max_nonlin_iters' must be type int.")
     elif not options["max_nonlin_iters"] > 0:
         raise ValueError("'max_nonlin_iters' must be > 0.")
 
     # max_conv_fails
-    if not isinstance(options["max_conv_fails"], int):
+    if not isinstance(options["max_conv_fails"], Integral):
         raise TypeError("'max_conv_fails' must be type int.")
     elif not options["max_conv_fails"] > 0:
         raise ValueError("'max_conv_fails' must be > 0.")
@@ -1130,7 +1134,7 @@ def _check_options(options: dict) -> None:
         pass
     elif not isinstance(constraints_idx, Iterable):
         raise TypeError("'constraints_idx' must be type Iterable.")
-    elif not all(isinstance(x, int) for x in constraints_idx):
+    elif not all(isinstance(x, Integral) for x in constraints_idx):
         raise TypeError("All 'constraints_idx' values must be type int.")
 
     # constraints_type
@@ -1167,7 +1171,7 @@ def _check_options(options: dict) -> None:
     num_events = options["num_events"]    
     if num_events == 0:
         pass
-    elif not isinstance(num_events, int):
+    elif not isinstance(num_events, Integral):
         raise TypeError("'num_events' must be type int.")
     elif num_events < 0:
         raise ValueError("'num_events' must be positive or zero.")


### PR DESCRIPTION
# Description
Type checks for the initialization options for both `CVODE` and `IDA` previously only accepted pure Python `float/int` types. There is no reason that equivalent `numpy` types should raise errors in these checks. This PR updates the type checks to allow `numpy` types in addition to the already accepted Python types.

This can technically be considered a new feature, and optimization, or a bug fix... depending on an individual's perspective.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
