### PR TITLE
Make CVODE/IDA example links uniquely named

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ You should also cite SUNDIALS following their recommendations [here](https://com
 ## Acknowledgements
 scikit-SUNDAE was originally inspired by [scikits-odes](https://scikits-odes.readthedocs.io/) which also offers Python bindings to SUNDIALS. The API for scikit-SUNDAE was mostly adopted from scikits-odes; however, all of our source code is original. If you are comparing the two:
 
-1. **scikits-odes:** includes iterative solvers and some optional solvers (e.g., LAPACK). The package only provides source distributions, so users must configure and compile SUNDAILS on their own.
-2. **scikit-SUNDAE:** includes sparse solvers, more flexible events function capabilities (e.g., direction detection and terminal flags), scipy-like output, and provides both binary and source distributions. Iterative and optional solvers are not available.
+1. **scikits-odes:** includes iterative solvers, preconditioners, and Jacobian-vector product interfaces. The package only provides source distributions, so users must configure and compile SUNDAILS on their own.
+2. **scikit-SUNDAE:** includes sparse solvers, more flexible events function capabilities (e.g., direction detection and terminal flags), scipy-like output, and provides both binary and source distributions. Iterative solvers and their respective options are not available.
 
 Our binary distributions include pre-compiled dynamic SUNDIALS libraries that also reference libraries like SuperLU_MT and OpenBLAS. These are self-contained and will not affect other, existing installations you may already have. To be in compliance with each library's distribution requirements, all scikit-SUNDAE distributions include a summary of all licenses (see the `LICENSES_bundled` file).
 

--- a/src/sksundae/cvode.py
+++ b/src/sksundae/cvode.py
@@ -155,11 +155,11 @@ class CVODE:
 
         Examples
         --------
-        The following example solves the stiff Van der Pol equation, which is a
-        classic ODE test problem. The same example is provided by `MATLAB`_ for
-        comparison.
+        The following example solves the stiff Van der Pol equation, a classic
+        ODE test problem. The same example is provided by `MATLAB <VDP-Ex_>`_
+        for comparison.
 
-        .. _MATLAB:
+        .. _VDP-Ex:
             https://www.mathworks.com/help/matlab/math/solve-stiff-odes.html
 
         .. code-block:: python

--- a/src/sksundae/ida.py
+++ b/src/sksundae/ida.py
@@ -164,7 +164,7 @@ class IDA:
         --------
         The following example solves the Robertson problem, which is a classic
         test problem for programs that solve stiff ODEs. A full description of
-        the problem is provided by `MATLAB`_. Note that while initializing the
+        the problem is provided by `MATLAB <Rob-Ex_>`_. While initializing the
         solver, ``algebraic_idx=[2]`` specifies ``y[2]`` is purely algebraic,
         and ``calc_initcond='yp0'`` tells the solver to determine the values
         for 'yp0' at 'tspan[0]' before starting to integrate. That is why 'yp0'
@@ -172,7 +172,7 @@ class IDA:
         to the residuals expressions actually gives ``yp0 = [-0.04, 0.04, 0]``.
         The initialization is checked against the correct answer after solving.
 
-        .. _MATLAB:
+        .. _Rob-Ex:
             https://mathworks.com/help/matlab/math/
             solve-differential-algebraic-equations-daes.html
 


### PR DESCRIPTION
# Description
Just a couple small changes to the `README` and making the links in the docstring examples unique so that if they ever appear on the same page they do not conflict.

## Type of change
Docs only.

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
