### PR TITLE
Add Jacobian-vector product interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NREL/scikit-sundae/)
 
 ### New Features
+- Implement interfaces for Jacobian-vector products ([#13](https://github.com/NREL/scikit-sundae/pull/13))
 - Allow preconditioning for iterative solvers ([#12](https://github.com/NREL/scikit-sundae/pull/12))
 - Enable OpenBLAS-linked LAPACK linear solvers ([#11](https://github.com/NREL/scikit-sundae/pull/11))
 - Add iterative linear solvers to IDA and CVODE ([#10](https://github.com/NREL/scikit-sundae/pull/10))

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 67">
-	<title>tests: 67</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 75">
+	<title>tests: 75</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">67</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">67</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">75</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">75</text>
 	</g>
 </svg>

--- a/src/sksundae/c_cvode.pxd
+++ b/src/sksundae/c_cvode.pxd
@@ -67,16 +67,23 @@ cdef extern from "cvode/cvode_ls.h":
 
     # user-supplied functions
     ctypedef int (*CVLsJacFn)(
-        sunrealtype t, N_Vector yy, N_Vector fy, SUNMatrix JJ, void* data,
+        sunrealtype tt, N_Vector yy, N_Vector yp, SUNMatrix JJ, void* data,
         N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except? -1
 
     ctypedef int (*CVLsPrecSetupFn)(
-        sunrealtype t, N_Vector yy, N_Vector fy, sunbooleantype jok, sunbooleantype* jcurPtr,
+        sunrealtype tt, N_Vector yy, N_Vector yp, sunbooleantype jok, sunbooleantype* jcurPtr,
         sunrealtype gamma, void* data) except? -1
 
     ctypedef int (*CVLsPrecSolveFn)(
-        sunrealtype t, N_Vector yy, N_Vector fy, N_Vector rv, N_Vector zv, sunrealtype gamma,
+        sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rv, N_Vector zv, sunrealtype gamma,
         sunrealtype delta, int lr, void* data) except? -1
+
+    ctypedef int (*CVLsJacTimesSetupFn)(
+        sunrealtype tt, N_Vector yy, N_Vector yp, void* data) except? -1
+
+    ctypedef int (*CVLsJacTimesVecFn)(
+        N_Vector vv, N_Vector Jv, sunrealtype tt, N_Vector yy, N_Vector yp, void* data,
+        N_Vector tmp) except? -1
 
     # exported functions
     int CVodeSetLinearSolver(void* mem, SUNLinearSolver LS, SUNMatrix A)
@@ -84,6 +91,7 @@ cdef extern from "cvode/cvode_ls.h":
     # optional inputs to LS interface
     int CVodeSetJacFn(void* mem, CVLsJacFn jacfn)
     int CVodeSetPreconditioner(void* mem, CVLsPrecSetupFn psetup, CVLsPrecSolveFn psolve)
+    int CVodeSetJacTimes(void* mem, CVLsJacTimesSetupFn jvsetup, CVLsJacTimesVecFn jvsolve)
 
     # optional outputs from LS interface
     int CVodeGetNumJacEvals(void* mem, long int* njevals)

--- a/src/sksundae/c_ida.pxd
+++ b/src/sksundae/c_ida.pxd
@@ -84,12 +84,21 @@ cdef extern from "ida/ida_ls.h":
         sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, N_Vector rv,
         N_Vector zv, sunrealtype cj, sunrealtype delta, void* data) except? -1
 
+    ctypedef int (*IDALsJacTimesSetupFn)(
+        sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, sunrealtype cj,
+        void* data) except? -1
+
+    ctypedef int (*IDALsJacTimesVecFn)(
+        sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, N_Vector vv, N_Vector Jv,
+        sunrealtype cj, void* data, N_Vector tmp1, N_Vector tmp2) except? -1
+
     # exported functions
     int IDASetLinearSolver(void* mem, SUNLinearSolver LS, SUNMatrix A)
 
     # optional inputs to LS interface
     int IDASetJacFn(void* mem, IDALsJacFn jacfn)
     int IDASetPreconditioner(void* mem, IDALsPrecSetupFn psetup, IDALsPrecSolveFn psolve)
+    int IDASetJacTimes(void* mem, IDALsJacTimesSetupFn jvsetup, IDALsJacTimesVecFn jvsolve)
 
     # optional outputs from LS interface
     int IDAGetNumJacEvals(void* mem, long int* njevals)

--- a/src/sksundae/cvode/__init__.py
+++ b/src/sksundae/cvode/__init__.py
@@ -7,9 +7,11 @@ with support for direct and iterative linear solvers, root finding, and more.
 
 from ._solver import CVODE, CVODEResult
 from ._precond import CVODEPrecond
+from ._jactimes import CVODEJacTimes
 
 __all__ = [
     'CVODE',
     'CVODEResult',
     'CVODEPrecond',
+    'CVODEJacTimes',
 ]

--- a/src/sksundae/cvode/_jactimes.py
+++ b/src/sksundae/cvode/_jactimes.py
@@ -1,0 +1,63 @@
+# cvode._jactimes.py
+
+from __future__ import annotations
+from typing import Callable
+
+
+class CVODEJacTimes:
+    """Jacobian-vector product."""
+
+    __slots__ = ('setupfn', 'solvefn')
+
+    def __init__(self, setupfn: Callable | None, solvefn: Callable) -> None:
+        """
+        Wrapper for passing Jacobian-vector product functions to CVODE. The
+        Jacobian-vector product interface is only supported by iterative solvers
+        (gmres, bicgstab, tfqmr).
+
+        Parameters
+        ----------
+        setupfn : Callable or None
+            A function to setup data before solving the Jacobian-vector product.
+            Use None if not needed. The required signature is in the notes.
+        solvefn : Callable
+            A function that solves for the Jacobian-vector product ``J*v`` (or
+            an approximation to it). The required signature is in the notes.
+
+        Raises
+        ------
+        TypeError
+            'setupfn' must be type Callable or None.
+        TypeError
+            'solvefn' must be type Callable.
+
+        Notes
+        -----
+        The solve and setup functions require specific function signatures. For
+        'solvefn' use ``f(t, y, yp, v, Jv[, userdata])``. Any return values are
+        ignored. Instead, the function should fill the pre-allocated memory for
+        'Jv' (a 1D array) with the solution (or approximation) to ``J*v``. Use
+        ``[:]`` to fill the array rather than overwriting it. For example,
+        ``Jv[:] = f(...)`` is correct whereas ``Jv = f(...)`` is not. The user
+        is responsible for managing their own Jacobian data if needed. 'setupfn'
+        can be used to help setup any needed values/data so that 'solvefn' is
+        not overly complex.
+
+        'setupfn' requires the signature ``f(t, y, yp[, userdata])``. As with
+        'solvefn', any return values are ignored. However, you can use the
+        function to define global variables or add them to ``userdata`` so they
+        can be passed to 'solvefn'. The order of function calls is always
+        'rhsfn' -> 'setupfn' -> 'solvefn' for each integration step.
+
+        """
+
+        if setupfn is None:
+            pass
+        elif not isinstance(setupfn, Callable):
+            raise TypeError("'setupfn' must be type Callable.")
+
+        if not isinstance(solvefn, Callable):
+            raise TypeError("'solvefn' must be type Callable.")
+
+        self.setupfn = setupfn
+        self.solvefn = solvefn

--- a/src/sksundae/cvode/_precond.py
+++ b/src/sksundae/cvode/_precond.py
@@ -5,26 +5,25 @@ from typing import Callable
 
 
 class CVODEPrecond:
-    """CVODE preconditioner."""
+    """Preconditioner wrapper."""
 
     __slots__ = ('setupfn', 'solvefn', 'side', '_prectype')
 
-    def __init__(self, solvefn: Callable, setupfn: Callable = None,
+    def __init__(self, setupfn: Callable | None, solvefn: Callable,
                  side: str = 'left') -> None:
         """
-        Wrapper for passing preconditioner data to CVODE. Preconditioning is
-        only supported by iterative solvers (gmres, bicgstab, tfqmr).
+        Wrapper for passing preconditioner functions to CVODE. Preconditioning
+        is only supported by iterative solvers (gmres, bicgstab, tfqmr).
 
         Parameters
         ----------
+        setupfn : Callable or None
+            A function to setup data before solving the preconditioned problem.
+            Use None if not needed. The required signature is in the notes.
         solvefn : Callable
             A function that solves the preconditioned problem ``P*zvec = rvec``.
             P is a preconditioner matrix approximating ``I - gamma*J``, at least
-            crudely. The required signature is given in the notes below.
-        setupfn : Callable or None, optional
-            An optional function to setup data before solving the preconditioned
-            problem. Defaults to None. The required signature is given in the
-            notes below.
+            crudely. The required signature is in the notes.
         side : {'left', 'right', 'both'}, optional
             The preconditioning type to use. Can be 'left', 'right', or 'both'.
             The default is 'left'.
@@ -66,10 +65,10 @@ class CVODEPrecond:
         add them to ``userdata`` so they can be passed to 'solvefn'. The inputs
         ``jok`` and ``jnew`` are designed to help optimize performance. The
         ``jok`` flag indicates whether Jacobian data from previous calls can be
-        reused (``jok = 1``) or if it must be recomputed from (``jok = 0``).
-        The ``jnew`` input is a single-item list that the user must control to
-        tell the solve whether or not the Jacobian data has been updated. An
-        outlined example is given below.
+        reused (``jok = 1``) or if it must be recomputed (``jok = 0``). The
+        ``jnew`` input is a single-item list that the user must control to tell
+        the solve whether the Jacobian data has been updated (``jnew[0] = 1``)
+        or not (``jnew[0] = 0``). An outlined example is given below.
 
         .. code-block:: python
 
@@ -94,13 +93,13 @@ class CVODEPrecond:
 
         """
 
-        if not isinstance(solvefn, Callable):
-            raise TypeError("'solvefn' must be type Callable.")
-
         if setupfn is None:
             pass
         elif not isinstance(setupfn, Callable):
             raise TypeError("'setupfn' must be type Callable.")
+
+        if not isinstance(solvefn, Callable):
+            raise TypeError("'solvefn' must be type Callable.")
 
         if side not in {'left', 'right', 'both'}:
             raise ValueError("'side' must be in {'left', 'right', 'both'}.")

--- a/src/sksundae/cvode/_solver.py
+++ b/src/sksundae/cvode/_solver.py
@@ -125,27 +125,36 @@ class CVODE:
             pre-allocated 2D matrix 'JJ' with values defined by the Jacobian
             ``JJ[i,j] = dyp_i/dy_j``. An internal finite difference method is
             applied when None (default).
+        precond : CVODEPrecond or None, optional
+            Preconditioner functions. Only compatible with iterative linear
+            solvers. Must be an instance of CVODEPrecond if not None (default).
+        jactimes : CVODEJacTimes or None, optional
+            Jacobian-vector product functions. Only compatible with iterative
+            linear solvers. Must be an instance of CVODEJacTimes when provided.
+            Difference quotient approximations are used with iterative solvers
+            if None (default).
 
         Notes
         -----
-        Return values from 'rhsfn', 'eventsfn', and 'jacfn' are ignored by the
-        solver. Instead the solver directly reads from pre-allocated memory.
-        The 'yp', 'events', and 'JJ' arrays from each user-defined callable
-        should be filled within each respective function. When setting values
-        across the entire array/matrix at once, don't forget to use ``[:]`` to
-        fill the existing array rather than overwriting it. For example, using
-        ``yp[:] = f(t, y)`` is correct whereas ``yp = f(t, y)`` is not.
+        Return values from all user-defined function (e.g., 'rhsfn', 'eventsfn',
+        and 'jacfn') are ignored by the solver. Instead the solver directly
+        reads from pre-allocated memory. Output arrays (e.g., 'yp', 'events',
+        and 'JJ') from each user-defined callable should be filled within each
+        respective function. When setting values across the entire array/matrix
+        at once, don't forget to use ``[:]`` to fill the existing array rather
+        than overwriting it. For example, using ``yp[:] = f(t, y)`` is correct
+        whereas ``yp = f(t, y)`` is not.
 
-        When 'rhsfn' (or 'eventsfn', or 'jacfn') require data outside of their
-        normal arguments, you can supply 'userdata' as an option. When given,
-        'userdata' must appear in the function signatures for ALL of 'rhsfn',
-        'eventsfn' (when not None), and 'jacfn' (when not None), even if it is
-        not used in all of these functions. Note that 'userdata' only takes up
-        one argument position; however, 'userdata' can be any Python object.
-        Therefore, to pass more than one extra argument you should pack all of
-        the data into a single tuple, dict, dataclass, etc. and pass them all
-        together as 'userdata'. The data can be unpacked as needed within a
-        function.
+        When any user-defined function require data outside of their normal
+        arguments, you can supply optional 'userdata'. When given, 'userdata'
+        must appear in ALL function signatures ('rhsfn', 'eventsfn', 'jacfn',
+        'precond', and 'jactimes') even if it is not used in all functions. Of
+        course this does not apply to functions that are provided as ``None``.
+        Note that 'userdata' only takes up one argument position; however,
+        'userdata' can be any Python object. Therefore, to pass more than one
+        extra argument you should pack all data into a single tuple, dict,
+        dataclass, etc. and pass them all together as 'userdata'. The data can
+        be unpacked as needed within the functions.
 
         References
         ----------
@@ -316,7 +325,7 @@ class CVODE:
 
 
 class CVODEResult(_CVODEResult):
-    """Results class for CVODE solver."""
+    """Results container."""
 
     def __init__(self, **kwargs) -> None:
         """

--- a/src/sksundae/ida/__init__.py
+++ b/src/sksundae/ida/__init__.py
@@ -7,9 +7,11 @@ and iterative linear solvers, root finding, and more.
 
 from ._solver import IDA, IDAResult
 from ._precond import IDAPrecond
+from ._jactimes import IDAJacTimes
 
 __all__ = [
     'IDA',
     'IDAResult',
     'IDAPrecond',
+    'IDAJacTimes',
 ]

--- a/src/sksundae/ida/_jactimes.py
+++ b/src/sksundae/ida/_jactimes.py
@@ -1,0 +1,63 @@
+# ida._jactimes.py
+
+from __future__ import annotations
+from typing import Callable
+
+
+class IDAJacTimes:
+    """Jacobian-vector product."""
+
+    __slots__ = ('setupfn', 'solvefn')
+
+    def __init__(self, setupfn: Callable | None, solvefn: Callable) -> None:
+        """
+        Wrapper for passing Jacobian-vector product functions to IDA. The
+        Jacobian-vector product interface is only supported by iterative solvers
+        (gmres, bicgstab, tfqmr).
+
+        Parameters
+        ----------
+        setupfn : Callable or None
+            A function to setup data before solving the Jacobian-vector product.
+            Use None if not needed. The required signature is in the notes.
+        solvefn : Callable
+            A function that solves for the Jacobian-vector product ``J*v`` (or
+            an approximation to it). The required signature is in the notes.
+
+        Raises
+        ------
+        TypeError
+            'setupfn' must be type Callable or None.
+        TypeError
+            'solvefn' must be type Callable.
+
+        Notes
+        -----
+        The solve and setup functions require specific function signatures. For
+        'solvefn' use ``f(t, y, yp, res, v, Jv, cj[, userdata])``. Any return
+        values are ignored. Instead, the function should fill the pre-allocated
+        memory for 'Jv' (a 1D array) with the solution (or approximation) to
+        ``J*v``. Use ``[:]`` to fill the array rather than overwriting it. For
+        example, ``Jv[:] = f(...)`` is correct whereas ``Jv = f(...)`` is not.
+        The user is responsible for managing their own Jacobian data if needed.
+        'setupfn' can be used to help setup any needed values/data so that
+        'solvefn' is not overly complex.
+
+        'setupfn' requires the signature ``f(t, y, yp, res, cj[, userdata])``.
+        As with 'solvefn', any return values are ignored. However, you can use
+        the function to define global variables or add them to ``userdata`` so
+        they can be passed to 'solvefn'. The order of function calls is always
+        'resfn' -> 'setupfn' -> 'solvefn' for each integration step.
+
+        """
+
+        if setupfn is None:
+            pass
+        elif not isinstance(setupfn, Callable):
+            raise TypeError("'setupfn' must be type Callable.")
+
+        if not isinstance(solvefn, Callable):
+            raise TypeError("'solvefn' must be type Callable.")
+
+        self.setupfn = setupfn
+        self.solvefn = solvefn

--- a/src/sksundae/ida/_precond.py
+++ b/src/sksundae/ida/_precond.py
@@ -5,27 +5,26 @@ from typing import Callable
 
 
 class IDAPrecond:
-    """IDA preconditioner."""
+    """Preconditioner wrapper."""
 
     __slots__ = ('setupfn', 'solvefn', 'side', '_prectype')
 
-    def __init__(self, solvefn: Callable, setupfn: Callable = None) -> None:
+    def __init__(self, setupfn: Callable | None, solvefn: Callable) -> None:
         """
-        Wrapper for passing preconditioner data to IDA. Preconditioning is
+        Wrapper for passing preconditioner functions to IDA. Preconditioning is
         only supported by iterative solvers (gmres, bicgstab, tfqmr). IDA only
         supports left preconditioning. Keep this in mind when defining your
         setup and solve functions.
 
         Parameters
         ----------
+        setupfn : Callable or None, optional
+            A function to setup data before solving the preconditioned problem.
+            Use None if not needed. The required signature is in the notes.
         solvefn : Callable
             A function that solves the preconditioned problem ``P*zvec = rvec``.
             P is a preconditioner matrix approximating the Jacobian, at least
-            crudely. The required signature is given in the notes below.
-        setupfn : Callable or None, optional
-            An optional function to setup data before solving the preconditioned
-            problem. Defaults to None. The required signature is given in the
-            notes below.
+            crudely. The required signature is in the notes.
 
         Raises
         ------
@@ -65,13 +64,13 @@ class IDAPrecond:
 
         """
 
-        if not isinstance(solvefn, Callable):
-            raise TypeError("'solvefn' must be type Callable.")
-
         if setupfn is None:
             pass
         elif not isinstance(setupfn, Callable):
             raise TypeError("'setupfn' must be type Callable.")
+
+        if not isinstance(solvefn, Callable):
+            raise TypeError("'solvefn' must be type Callable.")
 
         self.setupfn = setupfn
         self.solvefn = solvefn

--- a/src/sksundae/ida/_solver.py
+++ b/src/sksundae/ida/_solver.py
@@ -131,28 +131,36 @@ class IDA:
             The function should fill the pre-allocated 2D matrix 'JJ' with the
             values defined by ``JJ[i,j] = dres_i/dy_j + cj*dres_i/dyp_j``. An
             internal finite difference method is applied when None (default).
+        precond : IDAPrecond or None, optional
+            Preconditioner functions. Only compatible with iterative linear
+            solvers. Must be an instance of IDAPrecond if not None (default).
+        jactimes : IDAJacTimes or None, optional
+            Jacobian-vector product functions. Only compatible with iterative
+            linear solvers. Must be an instance of IDAJacTimes when provided.
+            Difference quotient approximations are used with iterative solvers
+            if None (default).
 
         Notes
         -----
-        Return values from 'resfn', 'eventsfn', and 'jacfn' are ignored by the
-        solver. Instead the solver directly reads from pre-allocated memory.
-        The 'res', 'events', and 'JJ' arrays from each user-defined callable
-        should be filled within each respective function. When setting values
-        across the entire array/matrix at once, don't forget to use ``[:]`` to
-        fill the existing array rather than overwriting it. For example, using
-        ``res[:] = F(t, y, yp)`` is correct whereas ``res = F(t, y, yp)`` is
-        not.
+        Return values from all user-defined function (e.g., 'resfn', 'eventsfn',
+        and 'jacfn') are ignored by the solver. Instead the solver directly
+        reads from pre-allocated memory. Output arrays (e.g., 'res', 'events',
+        and 'JJ') from each user-defined callable should be filled within each
+        respective function. When setting values across the entire array/matrix
+        at once, don't forget to use ``[:]`` to fill the existing array rather
+        than overwriting it. For example, using ``res[:] = F(t, y, yp)`` is
+        correct whereas ``res = F(t, y, yp)`` is not.
 
-        When 'resfn' (or 'eventsfn', or 'jacfn') require data outside of their
-        normal arguments, you can supply 'userdata' as an option. When given,
-        'userdata' must appear in the function signatures for ALL of 'resfn',
-        'eventsfn' (when not None), and 'jacfn' (when not None), even if it is
-        not used in all of these functions. Note that 'userdata' only takes up
-        one argument position; however, 'userdata' can be any Python object.
-        Therefore, to pass more than one extra argument you should pack all of
-        the data into a single tuple, dict, dataclass, etc. and pass them all
-        together as 'userdata'. The data can be unpacked as needed within a
-        function.
+        When any user-defined function require data outside of their normal
+        arguments, you can supply optional 'userdata'. When given, 'userdata'
+        must appear in ALL function signatures ('rhsfn', 'eventsfn', 'jacfn',
+        'precond', and 'jactimes') even if it is not used in all functions. Of
+        course this does not apply to functions that are provided as ``None``.
+        Note that 'userdata' only takes up one argument position; however,
+        'userdata' can be any Python object. Therefore, to pass more than one
+        extra argument you should pack all data into a single tuple, dict,
+        dataclass, etc. and pass them all together as 'userdata'. The data can
+        be unpacked as needed within the functions.
 
         References
         ----------
@@ -342,7 +350,7 @@ class IDA:
 
 
 class IDAResult(_IDAResult):
-    """Results class for IDA solver."""
+    """Results container."""
 
     def __init__(self, **kwargs) -> None:
         """


### PR DESCRIPTION
# Description
Allows the user to specify their own Jacobian-vector products rather than using the default difference quotients. This is the last user-defined function that needed to be implemented.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
