### PR TITLE
Use np.testing for tests where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Changed signature inspections to support decorated `jit` functions ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Optimizations
+- Use `np.testing` where possible in tests for more informative fail statements ([#14](https://github.com/NREL/scikit-sundae/pull/14))
 - Updates to be compliant with Cython deprecations of `IF/ELIF/ELSE` and `DEF` ([#5](https://github.com/NREL/scikit-sundae/pull/5))
 - Replace loops between 1D numpy arrays and SUNDIALS NVectors with single-line memory views and pointer addressing ([#5](https://github.com/NREL/scikit-sundae/pull/5))
 - Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))

--- a/tests/test_cvode.py
+++ b/tests/test_cvode.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae.cvode import CVODE, CVODEResult
 
@@ -29,12 +30,12 @@ def test_cvode_solve():
     tspan = np.linspace(0, 10, 11)  # normal solve - user picks times
     soln = solver.solve(tspan, y0)
     assert len(tspan) > 2 and len(tspan) == len(soln.t)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     tspan = np.array([0, 10])  # onestep solve - integrator picks times
     soln = solver.solve(tspan, y0)
     assert len(tspan) == 2 and len(soln.t) > 2
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_cvode_step():
@@ -46,14 +47,14 @@ def test_cvode_step():
         _ = solver.step(10)
 
     soln_0 = solver.init_step(0, y0)
-    assert np.allclose(soln_0.y, ode_soln(soln_0.t, y0))
+    npt.assert_allclose(soln_0.y, ode_soln(soln_0.t, y0))
 
     soln_10 = solver.step(10)
-    assert np.allclose(soln_10.y, ode_soln(soln_10.t, y0))
+    npt.assert_allclose(soln_10.y, ode_soln(soln_10.t, y0))
 
     soln_1000 = solver.step(1000, method='onestep', tstop=1000)
     assert soln_1000.t > 10 and soln_1000.t < 1000
-    assert np.allclose(soln_1000.y, ode_soln(soln_1000.t, y0))
+    npt.assert_allclose(soln_1000.y, ode_soln(soln_1000.t, y0))
 
 
 def test_cvode_userdata():
@@ -70,7 +71,7 @@ def test_cvode_userdata():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_cvode_method():
@@ -80,7 +81,7 @@ def test_cvode_method():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_cvode_atol():
@@ -92,7 +93,7 @@ def test_cvode_atol():
 
     solver = CVODE(ode, rtol=1e-9, atol=[1e-12, 1e-12])
     soln_0 = solver.init_step(0, y0)
-    assert np.allclose(soln_0.y, ode_soln(soln_0.t, y0))
+    npt.assert_allclose(soln_0.y, ode_soln(soln_0.t, y0))
 
 
 def test_cvode_linsolver():
@@ -106,7 +107,7 @@ def test_cvode_linsolver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 @pytest.mark.parametrize('linsolver', ['dense', 'band'])
@@ -124,7 +125,7 @@ def test_cvode_sparsity(linsolver):  # using cvLSSparseDQJac for dense/band
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_cvode_constraints():
@@ -144,7 +145,7 @@ def test_cvode_constraints():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_cvode_eventsfn():
@@ -161,13 +162,13 @@ def test_cvode_eventsfn():
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
     assert soln.t[-1] < tspan[-1]  # event was terminal
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
-    assert np.isclose(soln.i_events[0], [1])  # event detected correctly
-    assert np.isclose(soln.y_events[0][0], 1.55)
+    npt.assert_allclose(soln.i_events[0], [1])  # event detected correctly
+    npt.assert_allclose(soln.y_events[0][0], 1.55)
 
-    assert np.isclose(soln.t_events[0], soln.t[-1])  # event was concatenated
-    assert np.allclose(soln.y_events[0], soln.y[-1])
+    npt.assert_allclose(soln.t_events[0], soln.t[-1])  # event was concatenated
+    npt.assert_allclose(soln.y_events[0], soln.y[-1])
 
     eventsfn.terminal = [False]
 
@@ -175,11 +176,11 @@ def test_cvode_eventsfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.isclose(soln.t[-1], tspan[-1])  # event wasn't terminal
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.t[-1], tspan[-1])  # event wasn't terminal
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
-    assert np.isclose(soln.i_events[0], [1])  # event detected correctly
-    assert np.isclose(soln.y_events[0][0], 1.55)
+    npt.assert_allclose(soln.i_events[0], [1])  # event detected correctly
+    npt.assert_allclose(soln.y_events[0][0], 1.55)
 
     assert not np.isclose(soln.t_events[0], soln.t[-1])  # didn't concatenate
     assert not np.allclose(soln.y_events[0], soln.y[-1])
@@ -190,8 +191,8 @@ def test_cvode_eventsfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.isclose(soln.t[-1], tspan[-1])  # event didn't trigger
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.t[-1], tspan[-1])  # event didn't trigger
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     assert soln.i_events is None  # event didn't trigger
     assert soln.t_events is None
@@ -212,14 +213,14 @@ def test_cvode_jacfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     solver = CVODE(ode, rtol=1e-9, atol=1e-12, linsolver='band',
                    lband=0, uband=0, jacfn=jacfn)
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_failures_on_exceptions():
@@ -279,8 +280,8 @@ def test_CVODEResult():
     assert result.message == soln.message
     assert result.success == soln.success
     assert result.status == result.status
-    assert np.allclose(result.t, soln.t)
-    assert np.allclose(result.y, soln.y)
+    npt.assert_allclose(result.t, soln.t)
+    npt.assert_allclose(result.y, soln.y)
     assert result.i_events == soln.i_events  # Don't use allclose here b/c
     assert result.t_events == soln.t_events  # all events are None.
     assert result.y_events == soln.y_events

--- a/tests/test_cvode_iterative.py
+++ b/tests/test_cvode_iterative.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae.cvode import CVODE, CVODEPrecond, CVODEJacTimes
 
@@ -71,12 +72,12 @@ def test_iterative_no_precond(linsolver):
     tspan = np.linspace(0, 10, 11)  # normal solve - user picks times
     soln = solver.solve(tspan, y0)
     assert len(tspan) > 2 and len(tspan) == len(soln.t)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0), rtol=1e-5)
 
     tspan = np.array([0, 10])  # onestep solve - integrator picks times
     soln = solver.solve(tspan, y0)
     assert len(tspan) == 2 and len(soln.t) > 2
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0), rtol=1e-5)
 
 
 @pytest.mark.parametrize('linsolver', ('gmres', 'bicgstab', 'tfqmr'))

--- a/tests/test_cvode_lapack.py
+++ b/tests/test_cvode_lapack.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae import cvode
 from sksundae._cy_common import config
@@ -32,7 +33,7 @@ def test_lapackdense_solver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 @pytest.mark.skipif(not has_lapack, reason='LAPACK not enabled')
@@ -47,4 +48,4 @@ def test_lapackband_solver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))

--- a/tests/test_ida.py
+++ b/tests/test_ida.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae.ida import IDA, IDAResult
 
@@ -47,12 +48,12 @@ def test_ida_ode_solve():
     tspan = np.linspace(0, 10, 11)  # normal solve - user picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) > 2 and len(tspan) == len(soln.t)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     tspan = np.array([0, 10])  # onestep solve - integrator picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) == 2 and len(soln.t) > 2
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 def test_ida_ode_step():
@@ -65,14 +66,14 @@ def test_ida_ode_step():
         _ = solver.step(10)
 
     soln_0 = solver.init_step(0, y0, yp0)
-    assert np.allclose(soln_0.y, ode_soln(soln_0.t, y0))
+    npt.assert_allclose(soln_0.y, ode_soln(soln_0.t, y0))
 
     soln_10 = solver.step(10)
-    assert np.allclose(soln_10.y, ode_soln(soln_10.t, y0))
+    npt.assert_allclose(soln_10.y, ode_soln(soln_10.t, y0))
 
     soln_1000 = solver.step(1000, method='onestep', tstop=1000)
     assert soln_1000.t > 10 and soln_1000.t < 1000
-    assert np.allclose(soln_1000.y, ode_soln(soln_1000.t, y0))
+    npt.assert_allclose(soln_1000.y, ode_soln(soln_1000.t, y0))
 
 
 def test_ida_dae_solve():
@@ -84,12 +85,12 @@ def test_ida_dae_solve():
     tspan = np.linspace(0, 10, 11)  # normal solve - user picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) > 2 and len(tspan) == len(soln.t)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
     tspan = np.array([0, 10])  # onestep solve - integrator picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) == 2 and len(soln.t) > 2
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 def test_ida_dae_step():
@@ -102,14 +103,14 @@ def test_ida_dae_step():
         _ = solver.step(10)
 
     soln_0 = solver.init_step(0, y0, yp0)
-    assert np.allclose(soln_0.y, dae_soln(soln_0.t, y0))
+    npt.assert_allclose(soln_0.y, dae_soln(soln_0.t, y0))
 
     soln_10 = solver.step(10)
-    assert np.allclose(soln_10.y, dae_soln(soln_10.t, y0))
+    npt.assert_allclose(soln_10.y, dae_soln(soln_10.t, y0))
 
     soln_1000 = solver.step(1000, method='onestep', tstop=1000)
     assert soln_1000.t > 10 and soln_1000.t < 1000
-    assert np.allclose(soln_1000.y, dae_soln(soln_1000.t, y0))
+    npt.assert_allclose(soln_1000.y, dae_soln(soln_1000.t, y0))
 
 
 def test_ida_userdata():
@@ -128,7 +129,7 @@ def test_ida_userdata():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 def test_ida_initcond():
@@ -139,11 +140,11 @@ def test_ida_initcond():
                  calc_initcond='yp0')
 
     soln = solver.init_step(0, y0, [0, 0])
-    assert np.allclose(soln.yp, yp0)
+    npt.assert_allclose(soln.yp, yp0)
 
     tspan = np.array([0, 10])
     soln = solver.solve(tspan, y0, [0, 0])
-    assert np.allclose(soln.yp[0], yp0)
+    npt.assert_allclose(soln.yp[0], yp0)
 
 
 def test_ida_atol():
@@ -156,7 +157,7 @@ def test_ida_atol():
 
     solver = IDA(dae, rtol=1e-9, atol=[1e-12, 1e-12], algebraic_idx=[1])
     soln_0 = solver.init_step(0, y0, yp0)
-    assert np.allclose(soln_0.y, dae_soln(soln_0.t, y0))
+    npt.assert_allclose(soln_0.y, dae_soln(soln_0.t, y0))
 
 
 def test_ida_linsolver():
@@ -171,7 +172,7 @@ def test_ida_linsolver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
 
 @pytest.mark.parametrize('linsolver', ['dense', 'band'])
@@ -190,7 +191,7 @@ def test_ida_sparsity(linsolver):  # using idaLSSparseDQJac for dense/band
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 def test_ida_constraints():
@@ -211,7 +212,7 @@ def test_ida_constraints():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 def test_ida_eventsfn():
@@ -231,14 +232,14 @@ def test_ida_eventsfn():
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
     assert soln.t[-1] < tspan[-1]  # event was terminal
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
-    assert np.isclose(soln.i_events[0], [1])  # event detected correctly
-    assert np.isclose(soln.y_events[0][0], 1.55)
+    npt.assert_allclose(soln.i_events[0], [1])  # event detected correctly
+    npt.assert_allclose(soln.y_events[0][0], 1.55)
 
-    assert np.isclose(soln.t_events[0], soln.t[-1])  # event was concatenated
-    assert np.allclose(soln.y_events[0], soln.y[-1])
-    assert np.allclose(soln.yp_events[0], soln.yp[-1])
+    npt.assert_allclose(soln.t_events[0], soln.t[-1])  # event was concatenated
+    npt.assert_allclose(soln.y_events[0], soln.y[-1])
+    npt.assert_allclose(soln.yp_events[0], soln.yp[-1])
 
     eventsfn.terminal = [False]
 
@@ -247,11 +248,11 @@ def test_ida_eventsfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.isclose(soln.t[-1], tspan[-1])  # event wasn't terminal
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.t[-1], tspan[-1])  # event wasn't terminal
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
-    assert np.isclose(soln.i_events[0], [1])  # event detected correctly
-    assert np.isclose(soln.y_events[0][0], 1.55)
+    npt.assert_allclose(soln.i_events[0], [1])  # event detected correctly
+    npt.assert_allclose(soln.y_events[0][0], 1.55)
 
     assert not np.isclose(soln.t_events[0], soln.t[-1])  # didn't concatenate
     assert not np.allclose(soln.y_events[0], soln.y[-1])
@@ -263,8 +264,8 @@ def test_ida_eventsfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.isclose(soln.t[-1], tspan[-1])  # event didn't trigger
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.t[-1], tspan[-1])  # event didn't trigger
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
     assert soln.i_events is None  # event didn't trigger
     assert soln.t_events is None
@@ -288,14 +289,14 @@ def test_ida_jacfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     solver = IDA(ode, rtol=1e-9, atol=1e-12, linsolver='band',
                  lband=0, uband=0, jacfn=jacfn)
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, ode_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, ode_soln(soln.t, y0))
 
     y0 = np.array([1, 2])
     yp0 = np.array([0.1, 0.2])
@@ -309,14 +310,14 @@ def test_ida_jacfn():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
     solver = IDA(dae, rtol=1e-9, atol=1e-12, algebraic_idx=[1],
                  linsolver='band', lband=1, uband=0, jacfn=jacfn)
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 def test_failures_on_exceptions():
@@ -382,9 +383,9 @@ def test_IDAResult():
     assert result.message == soln.message
     assert result.success == soln.success
     assert result.status == result.status
-    assert np.allclose(result.t, soln.t)
-    assert np.allclose(result.y, soln.y)
-    assert np.allclose(result.yp, soln.yp)
+    npt.assert_allclose(result.t, soln.t)
+    npt.assert_allclose(result.y, soln.y)
+    npt.assert_allclose(result.yp, soln.yp)
     assert result.i_events == soln.i_events  # Don't use allclose here b/c
     assert result.t_events == soln.t_events  # all events are None.
     assert result.y_events == soln.y_events

--- a/tests/test_ida_iterative.py
+++ b/tests/test_ida_iterative.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae.ida import IDA, IDAPrecond, IDAJacTimes
 
@@ -75,12 +76,12 @@ def test_iterative_no_precond(linsolver):
     tspan = np.linspace(0, 10, 11)  # normal solve - user picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) > 2 and len(tspan) == len(soln.t)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
     tspan = np.array([0, 10])  # onestep solve - integrator picks times
     soln = solver.solve(tspan, y0, yp0)
     assert len(tspan) == 2 and len(soln.t) > 2
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 @pytest.mark.parametrize('linsolver', ('gmres', 'bicgstab', 'tfqmr'))

--- a/tests/test_ida_lapack.py
+++ b/tests/test_ida_lapack.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import numpy.testing as npt
 
 from sksundae import ida
 from sksundae._cy_common import config
@@ -34,7 +35,7 @@ def test_lapackdense_solver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))
 
 
 @pytest.mark.skipif(not has_lapack, reason='LAPACK not enabled')
@@ -50,4 +51,4 @@ def test_lapackband_solver():
 
     tspan = np.linspace(0, 10, 11)
     soln = solver.solve(tspan, y0, yp0)
-    assert np.allclose(soln.y, dae_soln(soln.t, y0))
+    npt.assert_allclose(soln.y, dae_soln(soln.t, y0))

--- a/tests/test_jacband.py
+++ b/tests/test_jacband.py
@@ -1,6 +1,8 @@
 import pytest
-import numpy as np
 import sksundae as sun
+
+import numpy as np
+import numpy.testing as npt
 
 from scipy import sparse
 
@@ -72,7 +74,7 @@ def test_cvode_jpattern():
         correct[2*i:2*(i+1), 2*i:2*(i+1)] = np.array([[0, 1], [1, 1]])
 
     approx = sun.jacband.j_pattern(cvode_narrow, t0, y0)
-    np.testing.assert_allclose(correct, approx)
+    npt.assert_allclose(correct, approx)
 
     # Van der Pol with wide pattern
     t0 = 0.
@@ -88,7 +90,7 @@ def test_cvode_jpattern():
     correct = sparse.diags(diags, offsets, shape=(2*N, 2*N)).toarray()
 
     approx = sun.jacband.j_pattern(cvode_wide, t0, y0)
-    np.testing.assert_allclose(correct, approx)
+    npt.assert_allclose(correct, approx)
 
 
 def test_ida_jpattern():
@@ -117,7 +119,7 @@ def test_ida_jpattern():
         correct[3*i:3*(i+1), 3*i:3*(i+1)] = np.ones((3, 3))
 
     approx = sun.jacband.j_pattern(ida_narrow, t0, y0, yp0)
-    np.testing.assert_allclose(correct, approx)
+    npt.assert_allclose(correct, approx)
 
     # Robertson with wide pattern
     t0 = 0.
@@ -140,7 +142,7 @@ def test_ida_jpattern():
     correct = sparse.diags(diags, offsets, shape=(3*N, 3*N)).toarray()
 
     approx = sun.jacband.j_pattern(ida_wide, t0, y0, yp0)
-    np.testing.assert_allclose(correct, approx)
+    npt.assert_allclose(correct, approx)
 
 
 def test_bandwidth():

--- a/tests/test_robertson.py
+++ b/tests/test_robertson.py
@@ -1,8 +1,10 @@
 import os
 
-import numpy as np
 import pandas as pd
 from sksundae import ida
+
+import numpy as np
+import numpy.testing as npt
 
 
 def resfn(t, y, yp, res):
@@ -25,5 +27,5 @@ def test_against_C_solution():
     soln.y[:, 1] *= 1e4  # Scale y1 values prior to comparison
     data.y1 *= 1e4
 
-    assert np.allclose(soln.t, data.t)
-    assert np.allclose(soln.y, data[['y0', 'y1', 'y2']])
+    npt.assert_allclose(soln.t, data.t)
+    npt.assert_allclose(soln.y, data[['y0', 'y1', 'y2']])

--- a/tests/test_van_der_pol.py
+++ b/tests/test_van_der_pol.py
@@ -1,8 +1,10 @@
 import os
 
-import numpy as np
 import pandas as pd
 from sksundae import cvode
+
+import numpy as np
+import numpy.testing as npt
 
 
 def rhsfn_nonstiff(t, y, yp):
@@ -42,5 +44,5 @@ def test_nonstiff_agaisnt_C_solution():
     solver = cvode.CVODE(rhsfn_nonstiff, rtol=1e-6, atol=1e-8)
     soln = solver.solve(tspan, y0)
 
-    assert np.allclose(soln.t, data.t)
-    assert np.allclose(soln.y, data[['y0', 'y1']], rtol=1e-4, atol=1e-6)
+    npt.assert_allclose(soln.t, data.t)
+    npt.assert_allclose(soln.y, data[['y0', 'y1']])

--- a/tests/test_van_der_pol.py
+++ b/tests/test_van_der_pol.py
@@ -45,4 +45,4 @@ def test_nonstiff_agaisnt_C_solution():
     soln = solver.solve(tspan, y0)
 
     npt.assert_allclose(soln.t, data.t)
-    npt.assert_allclose(soln.y, data[['y0', 'y1']])
+    npt.assert_allclose(soln.y, data[['y0', 'y1']], rtol=1e-5)


### PR DESCRIPTION
# Description
Moves tests to use `np.testing.assert_*` as much as possible. Statements generated upon failure are a lot more informative than the alternative `assert np.allclose`, as an example.

## Type of change
- [x] Optimization (back-end change that improves speed/readability/etc.)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
