### PR TITLE
Add function to reorder Jacobians with reduced bandwidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NREL/scikit-sundae/)
 
 ### New Features
+- Add `reduce_bandwidth` function to help restructure sparse problems ([#15](https://github.com/NREL/scikit-sundae/pull/15))
 - Implement interfaces for Jacobian-vector products ([#13](https://github.com/NREL/scikit-sundae/pull/13))
 - Allow preconditioning for iterative solvers ([#12](https://github.com/NREL/scikit-sundae/pull/12))
 - Enable OpenBLAS-linked LAPACK linear solvers ([#11](https://github.com/NREL/scikit-sundae/pull/11))

--- a/docs/source/user_guide/linear_solvers.rst
+++ b/docs/source/user_guide/linear_solvers.rst
@@ -22,7 +22,7 @@ Banded solvers are designed for systems where the Jacobian matrix is sparse and 
 When to use:
 
 * Use a band solver when the Jacobian matrix has a banded structure.
-* Beneficial for large systems. When possible, try to order your problem's systems of equations to `minimize the bandwidth`_.
+* Beneficial for large systems. When possible, try to order your problem's systems of equations to `minimize the bandwidth`_. For convenience we include a ``reduce_bandwidth`` function to help with this, found in the ``jacband`` module. It uses the reverse Cuthill-McKee heuristic algorithm from ``scipy.sparse.csgraph``. See the full documentation for more information.
 
 .. _minimize the bandwidth: https://sciendo.com/article/10.2478/awutm-2014-0019
 

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 75">
-	<title>tests: 75</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 76">
+	<title>tests: 76</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">75</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">75</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">76</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">76</text>
 	</g>
 </svg>

--- a/tests/test_jacband.py
+++ b/tests/test_jacband.py
@@ -202,7 +202,7 @@ def test_reduce_bandwidth():
     npt.assert_allclose(Bnp[inv_perm][:, inv_perm], Anp)
 
     # non-symmetric
-    Asp = sp.random(N, N, density=0.1, format='csc', rng=42)
+    Asp = sp.random(N, N, density=0.1, format='csc', random_state=42)
     wide_band = sun.jacband.bandwidth(Asp.todense())
 
     assert sp.issparse(Asp)


### PR DESCRIPTION
# Description
Adds a routine to help find a banded structure by rearranging sparsity patterns such that the non-zero elements are moved toward the main diagonal, i.e., reduces the bandwidth. The function is named `reduce_bandwidth` and can be found in the `jacband` module.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
