### PR TITLE
Fix memory leak that occurs when init_step is repeatedly called

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Extract tag version details
         id: tag
         run: |
@@ -37,7 +42,7 @@ jobs:
           BUILD_SDIST: 1  
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools numpy cython
+          pip install --upgrade setuptools numpy cython
 
           LOCAL_VERSION=$(python setup.py --version)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Bug Fixes
+- Fix memory leak when `init_step` is repeatedly called in `CVODE` and `IDA` ([#19](https://github.com/NREL/scikit-sundae/pull/19))
 - Add `sign_y` terms and default to `np.float64` for floating type in `j_pattern` ([#7](https://github.com/NREL/scikit-sundae/pull/7))
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ name = "scikit-sundae"
 readme = "README.md"
 dynamic = ["version"]
 requires-python = ">=3.9,<3.14"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE*"]
 description = "SUNDIALS bindings to differential aglebraic equation solvers."
-keywords = ["sundials", "dae", "ode", "integrator", "ivp"]
+keywords = ["sundials", "dae", "ode", "integrator", "ivp", "cvode", "ida"]
 authors = [
     { name = "Corey R. Randall" },
     { email = "corey.randall@nrel.gov" },
@@ -23,7 +24,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -36,13 +36,6 @@ dependencies = ["numpy", "scipy"]
 
 [tool.setuptools]
 include-package-data = true
-license-files = [
-    "NOTICE*",
-    "AUTHORS*",
-    "COPYING*",
-    "LICENSE*",
-    "LICENSES_bundled",
-]
 
 [tool.setuptools.dynamic]
 version = {attr = "sksundae.__version__"}
@@ -54,11 +47,11 @@ where = ["src"]
 docs = [
     "sphinx",
     "myst-nb",
+    "matplotlib",
     "sphinx-design",
     "sphinx-autoapi",
     "sphinx-copybutton",
     "pydata-sphinx-theme",
-    "matplotlib",
 ]
 tests = [
     "pandas",

--- a/src/sksundae/__init__.py
+++ b/src/sksundae/__init__.py
@@ -62,4 +62,4 @@ from . import jacband
 
 __all__ = ['ida', 'utils', 'cvode', 'jacband', 'SUNDIALS_VERSION']
 
-__version__ = '1.1.0.dev'
+__version__ = '1.1.0.dev0'

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -416,7 +416,6 @@ cdef class CVODE:
     cdef void* mem
     cdef SUNContext ctx
     cdef N_Vector atol
-    cdef N_Vector algidx
     cdef N_Vector constraints
     cdef N_Vector yy
     cdef SUNMatrix A 
@@ -424,12 +423,13 @@ cdef class CVODE:
     cdef sunindextype NEQ
     cdef AuxData aux
 
+    cdef object _size           # int
+    cdef object _malloc         # bool - flag for memory allocation
     cdef object _options        # dict[str, Any]
-    cdef object _initialized    # bool
+    cdef object _initialized    # bool - flag for init_step completion
 
     def __cinit__(self, object rhsfn, **options):
-        self.ctx = NULL
-        self.mem = NULL
+        self._free_memory()
         
         self._options = {
             "rhsfn": rhsfn,
@@ -551,7 +551,32 @@ cdef class CVODE:
         if flag < 0:
             raise RuntimeError("CVodetolerances - " + CVMESSAGES[flag])
 
-    cdef _init_step(self, sunrealtype t0, np.ndarray[DTYPE_t, ndim=1] y0):
+    cdef _free_memory(self):
+        if self.mem is not NULL:
+            CVodeFree(&self.mem)
+
+        if self.ctx is not NULL:
+            SUNContext_Free(&self.ctx)
+
+        if self.atol is not NULL:
+            N_VDestroy(self.atol)
+
+        if self.constraints is not NULL:
+            N_VDestroy(self.constraints)
+
+        if self.yy is not NULL:
+            N_VDestroy(self.yy)
+
+        if self.A is not NULL:
+            SUNMatDestroy(self.A)
+
+        if self.LS is not NULL:
+            SUNLinSolFree(self.LS)
+
+        self._size = None
+        self._malloc = False
+
+    cdef _setup(self, sunrealtype t0, np.ndarray[DTYPE_t, ndim=1] y0):
 
         # Enumerated steps roughly correspond to the SUNDIALS documentation,
         # available at https://sundials.readthedocs.io/en/latest/cvode/Usage.
@@ -575,10 +600,8 @@ cdef class CVODE:
         self.yy = N_VNew_Serial(self.NEQ, self.ctx)
         if self.yy is NULL:
             raise MemoryError("N_VNew_Serial returned a NULL pointer for yy.")
-
-        yy_tmp = y0.copy()
         
-        np2svec(yy_tmp, self.yy)
+        np2svec(y0.copy(), self.yy)
 
         # 5) Create CVODE object
         if self._options["method"].lower() == "adams":
@@ -726,9 +749,37 @@ cdef class CVODE:
             if flag < 0:
                 raise RuntimeError("CVodeSetConstraints - " + CVMESSAGES[flag])
 
-        svec2np(self.yy, yy_tmp)
+        self._size = self.NEQ
+        self._malloc = True
+        
+        return flag
+
+    cdef _init_step(self, sunrealtype t0, np.ndarray[DTYPE_t, ndim=1] y0):
+        cdef int flag
+
+        yy_tmp = y0.copy()
+
+        # Memory allocation and settings steps handled in _setup()... only runs
+        # on first call, or if the size of the system changes.
+
+        if not self._malloc:
+            flag = self._setup(t0, y0)
+
+        elif self._size != y0.size:
+            self._free_memory()
+            flag = self._setup(t0, y0)
+
+        else:
+            np2svec(yy_tmp, self.yy)
+            flag = CVodeReInit(self.mem, t0, self.yy)
+
+            if flag < 0:
+                raise RuntimeError("CVodeReInit - " + CVMESSAGES[flag])
 
         self._initialized = True
+
+        # Construct result instance to return
+        svec2np(self.yy, yy_tmp)
 
         nfev, njev = _collect_stats(self.mem)
 
@@ -987,22 +1038,7 @@ cdef class CVODE:
         return soln
 
     def __dealloc__(self):
-        if self.mem is not NULL:
-            CVodeFree(&self.mem)
-        if self.ctx is not NULL:
-            SUNContext_Free(&self.ctx)
-        if self.atol is not NULL:
-            N_VDestroy(self.atol)
-        if self.algidx is not NULL:
-            N_VDestroy(self.algidx)
-        if self.constraints is not NULL:
-            N_VDestroy(self.constraints)
-        if self.yy is not NULL:
-            N_VDestroy(self.yy)
-        if self.A is not NULL:
-            SUNMatDestroy(self.A)
-        if self.LS is not NULL:
-            SUNLinSolFree(self.LS)
+        self._free_memory()
 
 
 cdef _prepare_events(object eventsfn, int num_events):

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -554,24 +554,31 @@ cdef class CVODE:
     cdef _free_memory(self):
         if self.mem is not NULL:
             CVodeFree(&self.mem)
+            self.mem = NULL
 
         if self.ctx is not NULL:
             SUNContext_Free(&self.ctx)
+            self.ctx = NULL
 
         if self.atol is not NULL:
             N_VDestroy(self.atol)
+            self.atol = NULL
 
         if self.constraints is not NULL:
             N_VDestroy(self.constraints)
+            self.constraints = NULL
 
         if self.yy is not NULL:
             N_VDestroy(self.yy)
+            self.yy = NULL
 
         if self.A is not NULL:
             SUNMatDestroy(self.A)
+            self.A = NULL
 
         if self.LS is not NULL:
             SUNLinSolFree(self.LS)
+            self.LS = NULL
 
         self._size = None
         self._malloc = False
@@ -771,8 +778,8 @@ cdef class CVODE:
 
         else:
             np2svec(yy_tmp, self.yy)
+            
             flag = CVodeReInit(self.mem, t0, self.yy)
-
             if flag < 0:
                 raise RuntimeError("CVodeReInit - " + CVMESSAGES[flag])
 

--- a/src/sksundae/c_cvode.pxd
+++ b/src/sksundae/c_cvode.pxd
@@ -25,6 +25,7 @@ cdef extern from "cvode/cvode.h":
     # initialization functions
     void* CVodeCreate(int imethod, SUNContext ctx)
     int CVodeInit(void* mem, CVRhsFn rhsfn, sunrealtype t0, N_Vector y0)
+    int CVodeReInit(void* mem, sunrealtype t0, N_Vector y0)
 
     # tolerance input functions
     int CVodeSStolerances(void* mem, sunrealtype rtol, sunrealtype atol)

--- a/src/sksundae/c_ida.pxd
+++ b/src/sksundae/c_ida.pxd
@@ -25,6 +25,7 @@ cdef extern from "ida/ida.h":
     # initialization functions
     void* IDACreate(SUNContext ctx)
     int IDAInit(void* mem, IDAResFn resfn, sunrealtype t0, N_Vector y0, N_Vector yp0)
+    int IDAReInit(void* mem, sunrealtype t0, N_Vector y0, N_Vector yp0)
 
     # tolerance input functions
     int IDASStolerances(void* mem, sunrealtype rtol, sunrealtype atol)


### PR DESCRIPTION
# Description
The `init_step` methods in `CVODE` and `IDA` allocate memory for the solvers. In cases when `init_step` was repeatedly called, there was previously no check to free memory before the reallocation. This has been fixed by only allocating memory once, unless the problem size changes (i.e., the size of `y0` and/or `yp0`). If the size changes, memory is freed before reallocation. In cases where the size stays the same, `ReInit` from SUNDIALS is run to reinitialize the solver without requiring a new memory allocation.

Fixes #17 

The following code was run to ensure the fix was effective. Prior to the fix, memory allocation errors would occur when this script was run. Even in cases where the problem was small and no errors were raised, you could also see the amount of memory required by the process continue to grow. Now, the process memory is unchanged over time as `init_step` is repeatedly called.

```python
import psutil, os
import numpy as np

from sksundae.ida import IDA
from sksundae.cvode import CVODE


def rhsfn(t, y, yp):
    yp[:] = 0
    

proc = psutil.Process(os.getpid())

t0 = 0
y0 = np.zeros(10000)

s1 = CVODE(rhsfn)
for i in range(1000):
    zeros = s1.init_step(t0, y0)
    if i % 10 == 0:
        print(f"Step {i}: RSS = {proc.memory_info().rss / 1024**2:.2f} MB")
        
print("\n\n")


def resfn(t, y, yp, res):
    res[:] = yp
    

t0 = 0
y0 = np.ones(1000)
yp0 = np.zeros_like(y0)

s2 = IDA(resfn)
for i in range(1000):
    ones = s2.init_step(t0, y0, yp0)
    if i % 10 == 0:
        print(f"Step {i}: RSS = {proc.memory_info().rss / 1024**2:.2f} MB")
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
