### PR TITLE
Fix exception propagation for updated cython >= v3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade nox
-          pip install -vv .[tests]
+          pip install .[tests]
 
       - name: List info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade nox
-          pip install .[tests]
+          pip install -vv .[tests]
 
       - name: List info
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Bug Fixes
+- Resolve exception propagation consistently for Cython v3.1 and up ([#20](https://github.com/NREL/scikit-sundae/pull/20))
 - Fix memory leak when `init_step` is repeatedly called in `CVODE` and `IDA` ([#19](https://github.com/NREL/scikit-sundae/pull/19))
 - Add `sign_y` terms and default to `np.float64` for floating type in `j_pattern` ([#7](https://github.com/NREL/scikit-sundae/pull/7))
 

--- a/src/sksundae/_cy_cvode.pyx
+++ b/src/sksundae/_cy_cvode.pyx
@@ -236,10 +236,9 @@ cdef void _err_handler(int line, const char* func, const char* file,
                        SUNContext ctx) except *:
     """Custom error handler for shorter messages (no line or file)."""
     
-    decoded_func = func.decode("utf-8")
-    decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
-
     if not PyErr_Occurred():
+        decoded_func = func.decode("utf-8")
+        decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
         print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
 
 

--- a/src/sksundae/_cy_ida.pyx
+++ b/src/sksundae/_cy_ida.pyx
@@ -240,10 +240,9 @@ cdef void _err_handler(int line, const char* func, const char* file,
                        SUNContext ctx) except *:
     """Custom error handler for shorter messages (no line or file)."""
     
-    decoded_func = func.decode("utf-8")
-    decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
-
     if not PyErr_Occurred():
+        decoded_func = func.decode("utf-8")
+        decoded_msg = msg.decode("utf-8").replace(", ,", ",").strip()
         print(f"\n[{decoded_func}, Error: {err_code}] {decoded_msg}\n")
 
 


### PR DESCRIPTION
# Description
Updates to Cython (>= v3.1) were causing exception propagation tests to fail. Shifting commands into the conditional that checks if a Python error occurred or not resolved the issue. Builds and tests are now compatible with the newer Cython version.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
