### PR TITLE
Bound supported SUNDIALS versions in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 ### Optimizations
+- Bound supported SUNDIALS versions to >= 7.0.0 and < 7.3.0 ([#24](https://github.com/NREL/scikit-sundae/pull/24))
 
 ### Bug Fixes
 

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -106,7 +106,7 @@ In all cases where you are trying to install from the source distribution, you s
 ====================== ==============================
 scikit-SUNDAE Version  Supported SUNDIALS Version(s)
 ====================== ==============================
-1.0.x                   >=7.0
+1.0.x                   >=7.0, <7.3
 ====================== ==============================
 
 1. Make sure you have a C compiler installed. If you are using the Windows operating system, we recommend `Visual Studio`_, but if you have another preferred compiler that should work too. For MacOS and other Linux-based operating systems, we recommend `Clang`_, which can be installed through the terminal using::

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,16 @@
 import os
 import re
 import setuptools
+
 from warnings import warn
 
 import numpy
+
 from Cython.Build import cythonize
+from packaging.version import Version
+
+MIN_VERSION = Version('7.0.0')
+MAX_VERSION = Version('7.3.0')
 
 
 def find_sundials():
@@ -36,11 +42,11 @@ def find_sundials():
         if os.path.exists(CONFIG_H):
             return BASE, CONFIG_H
 
-    raise FileNotFoundError("Can't find SUNDIALS installation in any of the"
-                            f" {search_paths=}. Set the environment variable"
-                            " SUNDIALS_PREFIX to the parent directory of the"
-                            " 'include' and 'lib' directories and retry the"
-                            " installation.")
+    raise FileNotFoundError(
+        F"Can't find SUNDIALS installation in any of the {search_paths=}. Set"
+        " the environment variable SUNDIALS_PREFIX to the parent directory of"
+        " the 'include' and 'lib' directories and retry the installation."
+    )
 
 
 def parse_config_h(file):
@@ -79,10 +85,12 @@ def get_extensions():
 
     # Write the pxi file to match types to sundials_config.h
     SUNDIALS_VERSION = config.get('SUNDIALS_VERSION')
-    MAJOR_VERSION = SUNDIALS_VERSION.split('.')[0]
-    if int(MAJOR_VERSION) < 7:
-        raise RuntimeError(f"sksundae - incompatible {SUNDIALS_VERSION=}."
-                           " MAJOR_VERSION must be at least 7.")
+    if not (MIN_VERSION <= Version(SUNDIALS_VERSION) < MAX_VERSION):
+        raise RuntimeError(
+            f"This version of sksundae requires SUNDIALS >= v{MIN_VERSION} and"
+            f" < v{MAX_VERSION}, but found {SUNDIALS_VERSION=}. Please install"
+            " a supported version and rebuild sksundae."
+        )
 
     if config.get('SUNDIALS_SINGLE_PRECISION'):
         precision = 'float'


### PR DESCRIPTION
# Description
As more and more releases of both scikit-SUNDAE and SUNDIALS come out it will likely not be super easy to enforce source distributions be built against appropriate versions of SUNDIALS, i.e., versions that were tested against during development. It is also not worth it to always tests newer SUNDIALS versions against older versions of scikit-SUNDAE. 

Moving forward, when releases are made, the known supported SUNDIALS versions will be bound within the setup.py file. This PR therefore bounds sksundae v1.0.x to SUNDIALS versions >= 7.0.0 and < 7.3. 

## Type of change
- [x] Optimization (back-end change that improves speed/readability/etc.)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
