### PR TITLE
sundae->sksundae in RichResult docstring example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Use `micromamba` instead of `miniconda` in CI ([#3](https://github.com/NREL/scikit-sundae/pull/3))
 
 ### Bug Fixes
+- Fixed import typo in docstring examples for `RichResult` ([#29](https://github.com/NREL/scikit-sundae/pull/29))
 - Resolve exception propagation consistently for Cython v3.1 and up ([#20](https://github.com/NREL/scikit-sundae/pull/20))
 - Fix memory leak when `init_step` is repeatedly called in `CVODE` and `IDA` ([#19](https://github.com/NREL/scikit-sundae/pull/19))
 - Add `sign_y` terms and default to `np.float64` for floating type in `j_pattern` ([#7](https://github.com/NREL/scikit-sundae/pull/7))

--- a/src/sksundae/utils.py
+++ b/src/sksundae/utils.py
@@ -75,7 +75,7 @@ class RichResult:
 
         .. code-block:: python
 
-            from sundae.utils import RichResult
+            from sksundae.utils import RichResult
 
             result = RichResult(a=10, b=20, c=30)
 


### PR DESCRIPTION
# Description
Was using `import sundae` instead of `import sksundae` in docstring example. Simple fix, no changes to actual functionality.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [x] Spelling fix (non-breaking change which fixes an issue)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
