### PR TITLE
Try builds against SUNDIALS v7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NatLabRockies/scikit-sundae)
 
 ### New Features
+- Move to newest SUNDIALS v7.7 for CI builds/tests ([#52](https://github.com/NatLabRockies/scikit-sundae/pull/52))
 - Move to newest SUNDIALS v7.6 for CI builds/tests ([#44](https://github.com/NatLabRockies/scikit-sundae/pull/44))
 - Custom `__reduce__` methods, allowing solvers to be serialized ([#38](https://github.com/NatLabRockies/scikit-sundae/pull/38))
 

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -106,6 +106,7 @@ In all cases where you are trying to install from the source distribution, you s
 ====================== ==============================
 scikit-SUNDAE Version  Supported SUNDIALS Version(s)
 ====================== ==============================
+1.2.x [dev]             >=7.6, <7.8
 1.1.x                   >=7.3, <7.6
 1.0.x                   >=7.0, <7.3
 ====================== ==============================

--- a/environments/ci_environment.yml
+++ b/environments/ci_environment.yml
@@ -2,5 +2,5 @@ name: sun
 channels:
   - conda-forge
 dependencies:
-  - sundials=7.6
+  - sundials=7.7
   - libblas=*=*openblas

--- a/environments/rtd_environment.yml
+++ b/environments/rtd_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.14
-  - sundials=7.6
+  - sundials=7.7
   - libblas=*=*openblas
   - pip:
     - ../.[docs]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from Cython.Build import cythonize
 from packaging.version import Version
 
 MIN_VERSION = Version('7.6.0')
-MAX_VERSION = Version('7.7.0')
+MAX_VERSION = Version('7.8.0')
 
 
 def find_sundials():


### PR DESCRIPTION
# Description
SUNDIALS v7.7.0 was released and built on conda-forge. The new conda builds use GitHub actions for the Linux distributions instead of Azure and the maintainers removed the `DBLA_VENDOR=Generic` option, which was originally required so that builds used the `BLAS` and `LAPACK` libraries from the conda environment and not the defaults on the Linux build systems. Despite removing this option, builds seem to be okay for compiling against in `scikit-sundae`. This is likely because building the GitHub runners do not encounter the same issue as the Azure runners finding the `BLAS` and `LAPACK` libraries.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (any other clean up, maintenance, etc.)

# Key checklist
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.